### PR TITLE
fix(bug): reset marker counter after undo action

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ anyhow = "1.0"
 clap = { version = "4.4.4", features = ["derive"] }
 swayipc = { git = "https://github.com/JayceFayne/swayipc-rs.git", branch = "master" }
 libwayshot = "0.2.0"
+
+lazy_static = "1.4.0"

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -15,7 +15,7 @@ use relm4::{gtk, Component, ComponentParts, ComponentSender};
 
 use crate::math::Vec2D;
 use crate::style::{Color, Size, Style};
-use crate::tools::{Drawable, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
+use crate::tools::{self, Drawable, Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
 
 #[derive(Debug, Clone, Copy)]
 pub enum SketchBoardMessage {
@@ -255,6 +255,12 @@ impl SketchBoard {
         match self.drawables.pop() {
             Some(d) => {
                 self.redo_stack.push(d);
+
+                let mut marker = tools::MARKER_CURRENT_NUMBER.lock().unwrap();
+                if marker.next_number > 1 {
+                    marker.next_number -= 1
+                }
+
                 ToolUpdateResult::Redraw
             }
             None => ToolUpdateResult::Unmodified,

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -8,9 +8,17 @@ use crate::{math::Vec2D, sketch_board::MouseEventMsg};
 
 use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
 
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+
+lazy_static! {
+    // global variable to keep count of the Marker current number
+    pub static ref MARKER_CURRENT_NUMBER: Mutex<MarkerTool> = Mutex::new(MarkerTool::default());
+}
+
 pub struct MarkerTool {
     style: Style,
-    next_number: u16,
+    pub next_number: u16,
 }
 
 #[derive(Clone, Debug)]
@@ -88,15 +96,18 @@ impl Tool for MarkerTool {
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event {
             MouseEventMsg::Click(pos, button) => {
+                let mut current_marker = MARKER_CURRENT_NUMBER.lock().unwrap();
                 if button == MouseButton::Primary {
                     let marker = Marker {
                         pos,
-                        number: self.next_number,
+                        // number: self.next_number,
+                        number: current_marker.next_number,
                         style: self.style,
                     };
 
                     // increment for next
-                    self.next_number += 1;
+                    // self.next_number += 1;
+                    current_marker.next_number += 1;
 
                     ToolUpdateResult::Commit(marker.clone_box())
                 } else {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -101,6 +101,7 @@ pub use arrow::ArrowTool;
 pub use blur::BlurTool;
 pub use crop::CropTool;
 pub use line::LineTool;
+pub use marker::MARKER_CURRENT_NUMBER;
 pub use rectangle::RectangleTool;
 pub use text::TextTool;
 


### PR DESCRIPTION
This solves issue #8 
I would appreciate your feedback and any recommendations for improving this solution. 

## video showing bug fix

[satty-marker-undo-bug_fix.webm](https://github.com/gabm/satty/assets/71889751/f62b0a8c-756d-42ef-b0a2-8465bfcced32)

