### PR TITLE
fix `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "satty"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
Previously the package was incapable of being built through the lock file.

The package can now be built using `Cargo.lock`.