### PR TITLE
allow sending capture to stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ impl App {
             Some(display) => {
                 gtk::style_context_add_provider_for_display(&display, &css_provider, 1)
             }
-            None => println!("Cannot apply style"),
+            None => eprintln!("Cannot apply style"),
         }
     }
 }
@@ -277,7 +277,7 @@ fn main() -> Result<()> {
 
     match run_satty(args) {
         Err(e) => {
-            println!("Error: {e}");
+            eprintln!("Error: {e}");
             Err(e)
         }
         Ok(v) => Ok(v),

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,9 +224,7 @@ impl Component for App {
 
         // Toolbars
         let tools_toolbar = ToolsToolbar::builder()
-            .launch(ToolsToolbarConfig {
-                show_save_button: config.args.output_filename.is_some(),
-            })
+            .launch(ToolsToolbarConfig {})
             .forward(sketch_board.sender(), |e| SketchBoardInput::ToolbarEvent(e));
 
         let style_toolbar = StyleToolbar::builder()

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -142,7 +142,7 @@ impl SketchBoard {
             .renderer
             .render_to_window(&cx, self.scale_factor, &self.active_tool)
         {
-            println!("Error drawing: {:?}", e);
+            eprintln!("Error drawing: {:?}", e);
         }
     }
 
@@ -151,7 +151,7 @@ impl SketchBoard {
         let texture = match self.renderer.render_to_texture(&self.active_tool) {
             Ok(t) => t,
             Err(e) => {
-                println!("Error while creating texture: {e}");
+                eprintln!("Error while creating texture: {e}");
                 return;
             }
         };
@@ -169,7 +169,7 @@ impl SketchBoard {
                 if !o.ends_with(".png") {
                     msg = "The only supported format is png, but the filename does not end in png"
                         .to_string();
-                    println!("{msg}");
+                    eprintln!("{msg}");
                     sender
                         .output_sender()
                         .emit(SketchBoardOutput::ShowToast(msg.to_string()));
@@ -191,7 +191,7 @@ impl SketchBoard {
         let texture = match self.renderer.render_to_texture(&self.active_tool) {
             Ok(t) => t,
             Err(e) => {
-                println!("Error while creating texture: {e}");
+                eprintln!("Error while creating texture: {e}");
                 return;
             }
         };
@@ -204,7 +204,7 @@ impl SketchBoard {
                 ));
             }
             None => {
-                println!("Cannot save to clipboard");
+                eprintln!("Cannot save to clipboard");
                 return;
             }
         }
@@ -402,7 +402,7 @@ impl Component for SketchBoard {
             }
         };
 
-        //println!("Event={:?} Result={:?}", msg, result);
+        //eprintln!("Event={:?} Result={:?}", msg, result);
         match result {
             ToolUpdateResult::Commit(drawable) => {
                 self.renderer.commit(drawable);

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -16,13 +16,9 @@ use relm4::{
     prelude::*,
 };
 
-pub struct ToolsToolbar {
-    config: ToolsToolbarConfig,
-}
+pub struct ToolsToolbar {}
 
-pub struct ToolsToolbarConfig {
-    pub show_save_button: bool,
-}
+pub struct ToolsToolbarConfig {}
 
 pub struct StyleToolbar {
     custom_color: Color,
@@ -181,19 +177,17 @@ impl SimpleComponent for ToolsToolbar {
                 set_icon_name: "save-regular",
                 set_tooltip: "Save (Ctrl+S)",
                 connect_clicked[sender] => move |_| {sender.output_sender().emit(ToolbarEvent::SaveFile);},
-
-                set_visible: model.config.show_save_button
             },
 
         },
     }
 
     fn init(
-        config: Self::Init,
+        _config: Self::Init,
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let model = ToolsToolbar { config };
+        let model = ToolsToolbar {};
         let widgets = view_output!();
 
         // Tools Action for selecting tools


### PR DESCRIPTION
this is useful for piping the output to other programs, like wl-copy
as it prevents some race conditions with some programs using things like
wl-paste --watch.

Fixes #19

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
