### PR TITLE
Select tool in toolbar on startup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "rust-analyzer.linkedProjects": [
-        "./Cargo.toml"
-    ]
+  "rust-analyzer.linkedProjects": ["./Cargo.toml"],
+  "rust-analyzer.checkOnSave.command": "clippy"
 }

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,28 +1,63 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct CommandLine {
-    /// Name of the person to greet
-    #[arg(
-        short,
-        long,
-        help = "Path to input image or '-' to read from stdin."
-    )]
+    /// Path to input image or '-' to read from stdin
+    #[arg(short, long)]
     pub filename: String,
 
-    #[arg(long, help = "Start Satty in fullscreen mode.")]
+    /// Start Satty in fullscreen mode
+    #[arg(long)]
     pub fullscreen: bool,
 
-    #[arg(long, help = "Filename to use for saving action, omit to disable saving to file.")]
+    /// Filename to use for saving action, omit to disable saving to file
+    #[arg(long)]
     pub output_filename: Option<String>,
 
-    #[arg(long, help = "Exit directly after copy/save action.")]
+    /// Exit directly after copy/save action
+    #[arg(long)]
     pub early_exit: bool,
+
+    /// Select the tool on startup
+    #[arg(long, default_value_t, value_name = "TOOL")]
+    pub init_tool: Tools,
 }
 
 impl CommandLine {
     pub fn do_parse() -> Self {
         Self::parse()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum Tools {
+    #[default]
+    Pointer,
+    Crop,
+    Line,
+    Arrow,
+    Rectangle,
+    Text,
+    Marker,
+    Blur,
+    Brush,
+}
+
+impl std::fmt::Display for Tools {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Tools::*;
+        let s = match self {
+            Pointer => "pointer",
+            Crop => "crop",
+            Line => "line",
+            Arrow => "arrow",
+            Rectangle => "rectangle",
+            Text => "text",
+            Marker => "marker",
+            Blur => "blur",
+            Brush => "brush",
+        };
+        f.write_str(s)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ impl App {
         DisplayManager::get()
             .default_display()
             .and_then(|display| display.monitor_at_surface(&surface))
-            .and_then(|monitor| Some(monitor.geometry()))
+            .map(|monitor| monitor.geometry())
     }
 
     fn resize_window_initial(&self, root: &Window, sender: ComponentSender<Self>) {
@@ -211,6 +211,7 @@ impl Component for App {
             original_image: config.image.clone(),
             output_filename: config.args.output_filename.clone(),
             early_exit: config.args.early_exit,
+            init_tool: config.args.init_tool.into(),
         };
 
         let sketch_board = SketchBoard::builder().launch(sketch_board_config).forward(
@@ -226,12 +227,13 @@ impl Component for App {
         let tools_toolbar = ToolsToolbar::builder()
             .launch(ToolsToolbarConfig {
                 show_save_button: config.args.output_filename.is_some(),
+                init_tool: config.args.init_tool.into(),
             })
-            .forward(sketch_board.sender(), |e| SketchBoardInput::ToolbarEvent(e));
+            .forward(sketch_board.sender(), SketchBoardInput::ToolbarEvent);
 
         let style_toolbar = StyleToolbar::builder()
             .launch(())
-            .forward(sketch_board.sender(), |e| SketchBoardInput::ToolbarEvent(e));
+            .forward(sketch_board.sender(), SketchBoardInput::ToolbarEvent);
 
         // Model
         let model = App {
@@ -251,7 +253,7 @@ impl Component for App {
 }
 
 fn load_image(filename: &str) -> Result<Pixbuf> {
-    Ok(Pixbuf::from_file(filename).context("couldn't load image")?)
+    Pixbuf::from_file(filename).context("couldn't load image")
 }
 
 fn run_satty(args: CommandLine) -> Result<()> {

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -41,6 +41,7 @@ pub enum MouseButton {
     Secondary,
     Middle,
 }
+
 #[derive(Debug, Clone, Copy)]
 pub struct KeyEventMsg {
     pub key: Key,
@@ -102,9 +103,8 @@ impl InputEvent {
     }
 
     fn remap_event_coordinates(&mut self, scale: f64) {
-        match self {
-            InputEvent::MouseEvent(me) => Self::screen2image(&mut me.pos, scale),
-            _ => (),
+        if let InputEvent::MouseEvent(me) = self {
+            Self::screen2image(&mut me.pos, scale)
         };
     }
 }
@@ -113,6 +113,7 @@ pub struct SketchBoardConfig {
     pub original_image: Pixbuf,
     pub output_filename: Option<String>,
     pub early_exit: bool,
+    pub init_tool: Tools,
 }
 
 pub struct SketchBoard {
@@ -201,7 +202,6 @@ impl SketchBoard {
             }
             None => {
                 println!("Cannot save to clipboard");
-                return;
             }
         }
     }
@@ -418,7 +418,7 @@ impl Component for SketchBoard {
 
         let model = Self {
             handler: DrawHandler::new(),
-            active_tool: tools.get(&Tools::Pointer),
+            active_tool: tools.get(&config.init_tool),
             style: Style::default(),
             renderer: Renderer::new(config.original_image.clone(), tools.get_crop_tool()),
             scale_factor: 1.0,

--- a/src/style.rs
+++ b/src/style.rs
@@ -21,9 +21,10 @@ pub struct Color {
     pub a: u8,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
 pub enum Size {
     Small = 0,
+    #[default]
     Medium = 1,
     Large = 2,
 }
@@ -31,12 +32,6 @@ pub enum Size {
 impl Default for Color {
     fn default() -> Self {
         Self::orange()
-    }
-}
-
-impl Default for Size {
-    fn default() -> Self {
-        Size::Medium
     }
 }
 
@@ -53,8 +48,7 @@ impl ToVariant for Color {
 
 impl FromVariant for Color {
     fn from_variant(variant: &Variant) -> Option<Self> {
-        <(u8, u8, u8, u8)>::from_variant(&variant)
-            .and_then(|(r, g, b, a)| Some(Self { r, g, b, a }))
+        <(u8, u8, u8, u8)>::from_variant(variant).map(|(r, g, b, a)| Self { r, g, b, a })
     }
 }
 
@@ -92,7 +86,7 @@ impl Color {
         Self::new(200, 37, 184, 255)
     }
 
-    pub fn to_rgba_f64(&self) -> (f64, f64, f64, f64) {
+    pub fn to_rgba_f64(self) -> (f64, f64, f64, f64) {
         (
             (self.r as f64) / 255.0,
             (self.g as f64) / 255.0,
@@ -100,7 +94,7 @@ impl Color {
             (self.a as f64) / 255.0,
         )
     }
-    pub fn to_rgba_u32(&self) -> u32 {
+    pub fn to_rgba_u32(self) -> u32 {
         ((self.r as u32) << 24) | ((self.g as u32) << 16) | ((self.b as u32) << 8) | (self.a as u32)
     }
 }
@@ -116,16 +110,17 @@ impl From<RGBA> for Color {
     }
 }
 
-impl Into<RGBA> for Color {
-    fn into(self) -> RGBA {
-        RGBA::new(
-            self.r as f32 / 255.0,
-            self.g as f32 / 255.0,
-            self.b as f32 / 255.0,
-            self.a as f32 / 255.0,
+impl From<Color> for RGBA {
+    fn from(color: Color) -> Self {
+        Self::new(
+            color.r as f32 / 255.0,
+            color.g as f32 / 255.0,
+            color.b as f32 / 255.0,
+            color.a as f32 / 255.0,
         )
     }
 }
+
 impl StaticVariantType for Size {
     fn static_variant_type() -> Cow<'static, VariantTy> {
         Cow::Borrowed(VariantTy::UINT32)
@@ -150,24 +145,24 @@ impl FromVariant for Size {
 }
 
 impl Size {
-    pub fn to_text_size(&self) -> i32 {
-        match *self {
+    pub fn to_text_size(self) -> i32 {
+        match self {
             Size::Small => 12 * SCALE,
             Size::Medium => 18 * SCALE,
             Size::Large => 32 * SCALE,
         }
     }
 
-    pub fn to_line_width(&self) -> f64 {
-        match *self {
+    pub fn to_line_width(self) -> f64 {
+        match self {
             Size::Small => 2.0,
             Size::Medium => 3.0,
             Size::Large => 5.0,
         }
     }
 
-    pub fn to_blur_factor(&self) -> f64 {
-        match *self {
+    pub fn to_blur_factor(self) -> f64 {
+        match self {
             Size::Small => 6.0,
             Size::Medium => 10.0,
             Size::Large => 20.0,

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -35,7 +35,7 @@ impl Drawable for BrushDrawable {
         cx.set_source_rgba(r, g, b, a);
         cx.set_line_join(pangocairo::cairo::LineJoin::Bevel);
 
-        if self.points.len() == 0 {
+        if self.points.is_empty() {
             cx.arc(
                 self.start.x,
                 self.start.y,
@@ -44,7 +44,7 @@ impl Drawable for BrushDrawable {
                 2.0 * PI,
             );
             cx.fill()?;
-        } else if self.points.len() > 0 {
+        } else {
             cx.move_to(self.start.x, self.start.y);
 
             for p in &self.points {

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -36,10 +36,8 @@ impl Crop {
     }
 
     pub fn get_rectangle(&self) -> Option<(Vec2D, Vec2D)> {
-        self.size.and_then(|size| {
-            let (pos, size) = math::rect_ensure_positive_size(self.pos, size);
-            Some((pos, size))
-        })
+        self.size
+            .map(|size| math::rect_ensure_positive_size(self.pos, size))
     }
 }
 
@@ -154,15 +152,9 @@ impl CropTool {
         }
     }
     fn test_handle_hit(&self, mouse_pos: Vec2D) -> Option<(CropHandle, Vec2D, Vec2D)> {
-        let crop = match &self.crop {
-            Some(c) => c,
-            None => return None,
-        };
+        let crop = self.crop.as_ref()?;
 
-        let crop_size = match crop.size {
-            Some(s) => s,
-            None => return None,
-        };
+        let crop_size = crop.size?;
         let crop_pos = crop.pos;
 
         const MAX_DISTANCE2: f64 = (Crop::HANDLE_BORDER + Crop::HANDLE_RADIUS)
@@ -301,14 +293,12 @@ impl CropTool {
     }
 
     fn end_drag(&mut self, direction: Vec2D) -> ToolUpdateResult {
-        let crop = match &mut self.crop {
-            Some(c) => c,
-            None => return ToolUpdateResult::Unmodified,
+        let Some(crop) = &mut self.crop else {
+            return ToolUpdateResult::Unmodified;
         };
 
-        let action = match &self.action {
-            Some(a) => a,
-            None => return ToolUpdateResult::Unmodified,
+        let Some(action) = &self.action else {
+            return ToolUpdateResult::Unmodified;
         };
 
         match action {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -9,6 +9,7 @@ use pangocairo::cairo::ImageSurface;
 use relm4::gtk::cairo::Context;
 
 use crate::{
+    command_line,
     sketch_board::{InputEvent, KeyEventMsg, MouseEventMsg},
     style::Style,
 };
@@ -189,5 +190,21 @@ impl FromVariant for Tools {
             8 => Some(Tools::Brush),
             _ => None,
         })
+    }
+}
+
+impl From<command_line::Tools> for Tools {
+    fn from(tool: command_line::Tools) -> Self {
+        match tool {
+            command_line::Tools::Pointer => Self::Pointer,
+            command_line::Tools::Crop => Self::Crop,
+            command_line::Tools::Line => Self::Line,
+            command_line::Tools::Arrow => Self::Arrow,
+            command_line::Tools::Rectangle => Self::Rectangle,
+            command_line::Tools::Text => Self::Text,
+            command_line::Tools::Marker => Self::Marker,
+            command_line::Tools::Blur => Self::Blur,
+            command_line::Tools::Brush => Self::Brush,
+        }
     }
 }

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -246,7 +246,7 @@ impl TextTool {
 
         match action {
             Action::Delete => {
-                let mut end_cursor_itr = start_cursor_itr.clone();
+                let mut end_cursor_itr = start_cursor_itr;
 
                 match action_scope {
                     ActionScope::ForwardChar => end_cursor_itr.forward_char(),
@@ -257,13 +257,13 @@ impl TextTool {
 
                 if text_buffer.delete_interactive(&mut start_cursor_itr, &mut end_cursor_itr, true)
                 {
-                    return ToolUpdateResult::Redraw;
+                    ToolUpdateResult::Redraw
                 } else {
-                    return ToolUpdateResult::Unmodified;
+                    ToolUpdateResult::Unmodified
                 }
             }
             Action::MoveCursor => {
-                let mut cursor_itr = start_cursor_itr.clone();
+                let mut cursor_itr = start_cursor_itr;
                 match action_scope {
                     ActionScope::ForwardChar => cursor_itr.forward_char(),
                     ActionScope::BackwardChar => cursor_itr.backward_char(),
@@ -275,9 +275,9 @@ impl TextTool {
                 let new_cursor_itr = text_buffer.iter_at_mark(&text_buffer.get_insert());
 
                 if new_cursor_itr != start_cursor_itr {
-                    return ToolUpdateResult::Redraw;
+                    ToolUpdateResult::Redraw
                 } else {
-                    return ToolUpdateResult::Unmodified;
+                    ToolUpdateResult::Unmodified
                 }
             }
         }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -22,6 +22,7 @@ pub struct ToolsToolbar {
 
 pub struct ToolsToolbarConfig {
     pub show_save_button: bool,
+    pub init_tool: Tools,
 }
 
 pub struct StyleToolbar {
@@ -198,13 +199,15 @@ impl SimpleComponent for ToolsToolbar {
 
         // Tools Action for selecting tools
         let sender_tmp: ComponentSender<ToolsToolbar> = sender.clone();
-        let tool_action: RelmAction<ToolsAction> =
-            RelmAction::new_stateful_with_target_value(&Tools::Pointer, move |_, state, value| {
+        let tool_action: RelmAction<ToolsAction> = RelmAction::new_stateful_with_target_value(
+            &model.config.init_tool,
+            move |_, state, value| {
                 *state = value;
                 sender_tmp
                     .output_sender()
                     .emit(ToolbarEvent::ToolSelected(*state));
-            });
+            },
+        );
 
         let mut group = RelmActionGroup::<ToolsToolbarActionGroup>::new();
         group.add_action(tool_action);
@@ -238,7 +241,7 @@ impl StyleToolbar {
                 .choose_rgba_future(root.as_ref(), current_color.as_ref())
                 .await
                 .ok()
-                .and_then(|c| Some(Color::from_gdk(c)));
+                .map(Color::from_gdk);
 
             sender.input(StyleToolbarInput::ColorDialogFinished(color));
         });


### PR DESCRIPTION
Implementation of https://github.com/gabm/Satty/issues/21

There are some points I need to explain:

- I defined a struct `Tools` (in `crate::command_line`) copied from `crate::tools::Tools` for the latent demand of generating completion scripts in future.
- I utilized [clap doc-comments](https://docs.rs/clap/latest/clap/_derive/index.html#doc-comments). It will strip the end `.`s of help information so I striped them manually.
- I optimize the code according to rust linter **clippy** within a commit. The new code is equivalent to the old, you don't need to spend too much time to review them.


