### PR TITLE
fix: bump satty to 0.7.0 in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "satty"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
It fixes a build failed on Nix.

The same issue but another package: https://github.com/NixOS/nixpkgs/issues/160975