### PR TITLE
Fix Satty for older versions of GTK4 (Ubuntu 22.04)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 
 
 [dependencies]
-relm4 = { version = "0.6.2", features = ["macros", "libadwaita", "gnome_44"] }
+relm4 = { version = "0.6.2", features = ["macros", "libadwaita", "gnome_42"] }
 pangocairo = "0.17.10"
 tokio = { version = "1.32.0", features = ["full"] }
 gdk-pixbuf = "0.17.2"

--- a/release.nu
+++ b/release.nu
@@ -1,0 +1,143 @@
+#!/usr/bin/env nu
+
+use std assert
+
+export def main [version: string] {   
+    # make sure the working tree is clean
+    assert_repo_is_clean
+
+    let read_version = version_read_cargo_toml
+    let requested_version = $version | version_parse
+    let requested_version_tag = $requested_version | version_to_string
+
+    $"Updating version from ($read_version | version_print) to ($requested_version | version_print)" | echo_section_headline
+
+    if not (is_newer $read_version $requested_version) {
+        echo "Requested version is older than current verion. Aborting."
+        exit 1
+    }
+
+    # update the cargo toml
+    patch_cargo_toml $requested_version
+
+    # update cargo lock
+    update_cargo_lock 
+
+    # commit 
+    git_commit $requested_version_tag
+
+    # tag a new git version
+    git_tag $requested_version_tag
+
+    # build artifact
+    build_artifact
+
+    ## from here on we go online!
+    # push
+    git_push 
+
+    # create release
+    github_release $requested_version_tag
+
+    # upload artifact
+    upload_artifact $requested_version_tag
+}
+
+
+def echo_section_headline []: string -> nothing {
+    echo $"\n(ansi yellow)++ ($in)(ansi reset)"
+}
+
+def assert_repo_is_clean [] {
+    if (git diff --quiet | complete | get exit_code) != 0 {
+        echo "The git repository is not clean! Aborting..."
+        exit 1
+    } else {}
+}
+
+def git_tag [tag: string] {
+    assert_repo_is_clean
+
+    $"Creating Git Tag ($tag) " | echo_section_headline
+    git tag ($tag)
+}
+
+def git_push [] {
+    "Pushing to GitHub" | echo_section_headline
+    git push; git push --tags
+}
+
+def patch_cargo_toml [version: list<int>] {
+    "Updating Cargo.toml" | echo_section_headline
+    let sed_string = $"'/package/,/version =/{s/version.*/version = \"($version | str join '.')\"/}'"
+    sed -i $sed_string Cargo.toml
+    git --no-pager diff
+}
+
+def update_cargo_lock [] {
+    "Updating Cargo.lock" | echo_section_headline
+    cargo generate-lockfile
+}
+
+def git_commit [tag: string] {
+    "Commiting..." | echo_section_headline
+    git commit -am $"Updating version to ($tag)"
+}
+
+def github_release [tag: string] {
+    $"Creating GitHub release ($tag)" | echo_section_headline    
+    gh release create $tag    
+}
+
+def build_artifact [] {
+    "Building Artifact" | echo_section_headline
+    make package
+}
+
+def upload_artifact [tag: string] {
+    "Uploading Artifact" | echo_section_headline
+    gh release upload $tag $"satty-($tag)-x86_64.tar.gz"
+}
+
+def version_parse []: string -> list<int> {
+    $in | str trim -c 'v' --left | split row '.' | each {|n| into int }
+}
+
+def version_to_string []: list<int> -> string {
+    $"v($in | str join '.')"
+}
+
+def version_read_cargo_toml []: nothing -> list<int> {
+    open Cargo.toml | get package.version | version_parse
+}
+
+def version_print []: list<int> -> nothing {
+    echo $"($in | version_to_string)"
+}
+
+def is_newer [
+    old: list<int>,
+    new: list<int>
+    ]: nothing -> bool {
+    
+    let length = [($old | length) ($new | length)] | math min
+
+    for i in 0..<($length) {
+        if ($new | get $i) > ($old | get $i) {
+            return true
+        } else {}
+        if ($new | get $i) < ($old | get $i) {
+            return false
+        } else {}
+    }
+
+    return false
+}
+
+#[test]
+def test_versions [] {
+    assert (is_newer [1 0 0] [2 0 0]) "major version"
+    assert (is_newer [1 0 0] [1 1]) "minor version, shorter"
+    assert not (is_newer [1 1 0] [1 1]) "minor version, shorter"
+    assert not (is_newer [1 1 0] [0 1]) "minor version, shorter"
+}


### PR DESCRIPTION
Satty currently requires GTK version 4.10 or newer. That prevents it from running on the current Ubuntu 22.04 LTS as seen in #36. 

The decision has been made to keep support for the current LTS and some time after the new LTS is released to give users time to switch. So I implemented the now deprecated way of choosing colors but therefore lowering the requirement to GTK.