### PR TITLE
feat: save after copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="assets/satty.svg" height="42"> Satty: Modern Screenshot Annotation. 
+# <img src="assets/satty.svg" height="42"> Satty: Modern Screenshot Annotation.
 
 Satty is a screenshot annotation tool inspired by [Swappy](https://github.com/jtheoof/swappy) and [Flameshot](https://flameshot.org/).
 
@@ -69,6 +69,8 @@ copy-command = "wl-copy"
 annotation-size-factor = 2
 # Filename to use for saving action. Omit to disable saving to file. Might contain format specifiers: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
+# Also save screenshot to a file after copy action
+save-on-copy = false
 
 # custom colours for the colour palette
 [color-palette]
@@ -83,7 +85,7 @@ custom= "#008000"
 ### Command Line
 
 ```sh
-» satty --help                
+» satty --help
 Modern Screenshot Annotation. A Screenshot Annotation Tool inspired by Swappy and Flameshot.
 
 Usage: satty [OPTIONS] --filename <FILENAME>
@@ -105,6 +107,8 @@ Options:
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
           Increase or decrease the size of the annotations
+      --save-on-copy
+          Also save screenshot to a file after copy action
   -h, --help
           Print help
   -V, --version
@@ -135,7 +139,7 @@ PREFIX=/use/local make install
 PREFIX=/use/local make uninstall
 ```
 
-## Dependencies 
+## Dependencies
 
 Satty is based on GTK-4 and Adwaita.
 
@@ -146,7 +150,7 @@ Satty is based on GTK-4 and Adwaita.
 
 ### Arch Linux & Gentoo
 
-- pango 
+- pango
 - glib2
 - cairo
 - libadwaita

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ copy-command = "wl-copy"
 annotation-size-factor = 2
 # Filename to use for saving action. Omit to disable saving to file. Might contain format specifiers: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
-# Also save screenshot to a file after copy action
-save-on-copy = false
+# After copying the screenshot, save it to a file as well
+save-after-copy = false
 
 # custom colours for the colour palette
 [color-palette]
@@ -107,8 +107,8 @@ Options:
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
           Increase or decrease the size of the annotations
-      --save-on-copy
-          Also save screenshot to a file after copy action
+      --save-after-copy
+          After copying the screenshot, save it to a file as well
   -h, --help
           Print help
   -V, --version

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,8 @@ copy-command = "wl-copy"
 annotation-size-factor = 2
 # Filename to use for saving action. Omit to disable saving to file. Might contain format specifiers: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
+# Also save screenshot to a file after copy action
+save-on-copy = false
 
 # custom colours for the colour palette
 [color-palette]

--- a/config.toml
+++ b/config.toml
@@ -11,8 +11,8 @@ copy-command = "wl-copy"
 annotation-size-factor = 2
 # Filename to use for saving action. Omit to disable saving to file. Might contain format specifiers: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
-# Also save screenshot to a file after copy action
-save-on-copy = false
+# After copying the screenshot, save it to a file as well
+save-after-copy = false
 
 # custom colours for the colour palette
 [color-palette]

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -36,9 +36,9 @@ pub struct CommandLine {
     #[arg(long)]
     pub annotation_size_factor: Option<f64>,
 
-    /// Also save screenshot to a file after copy action
+    /// After copying the screenshot, save it to a file as well
     #[arg(long)]
-    pub save_on_copy: bool,
+    pub save_after_copy: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -35,6 +35,10 @@ pub struct CommandLine {
     /// Increase or decrease the size of the annotations
     #[arg(long)]
     pub annotation_size_factor: Option<f64>,
+
+    /// Also save screenshot to a file after copy action
+    #[arg(long)]
+    pub save_on_copy: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -35,6 +35,7 @@ pub struct Configuration {
     initial_tool: Tools,
     copy_command: Option<String>,
     annotation_size_factor: f64,
+    save_on_copy: bool,
     color_palette: ColorPalette,
 }
 
@@ -138,6 +139,9 @@ impl Configuration {
         if let Some(v) = general.annotation_size_factor {
             self.annotation_size_factor = v;
         }
+        if let Some(v) = general.save_on_copy {
+            self.save_on_copy = v;
+        }
     }
     fn merge(&mut self, file: Option<ConfigurationFile>, command_line: CommandLine) {
         // input_filename is required and needs to be overwritten
@@ -172,6 +176,9 @@ impl Configuration {
         if let Some(v) = command_line.annotation_size_factor {
             self.annotation_size_factor = v;
         }
+        if command_line.save_on_copy {
+            self.save_on_copy = command_line.save_on_copy;
+        }
     }
 
     pub fn early_exit(&self) -> bool {
@@ -202,6 +209,10 @@ impl Configuration {
         self.annotation_size_factor
     }
 
+    pub fn save_on_copy(&self) -> bool {
+        self.save_on_copy
+    }
+
     pub fn color_palette(&self) -> &ColorPalette {
         &self.color_palette
     }
@@ -217,6 +228,7 @@ impl Default for Configuration {
             initial_tool: Tools::Pointer,
             copy_command: None,
             annotation_size_factor: 1.0f64,
+            save_on_copy: false,
             color_palette: ColorPalette::default(),
         }
     }
@@ -251,6 +263,7 @@ struct ConfiguationFileGeneral {
     copy_command: Option<String>,
     annotation_size_factor: Option<f64>,
     output_filename: Option<String>,
+    save_on_copy: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -35,7 +35,7 @@ pub struct Configuration {
     initial_tool: Tools,
     copy_command: Option<String>,
     annotation_size_factor: f64,
-    save_on_copy: bool,
+    save_after_copy: bool,
     color_palette: ColorPalette,
 }
 
@@ -139,8 +139,8 @@ impl Configuration {
         if let Some(v) = general.annotation_size_factor {
             self.annotation_size_factor = v;
         }
-        if let Some(v) = general.save_on_copy {
-            self.save_on_copy = v;
+        if let Some(v) = general.save_after_copy {
+            self.save_after_copy = v;
         }
     }
     fn merge(&mut self, file: Option<ConfigurationFile>, command_line: CommandLine) {
@@ -176,8 +176,8 @@ impl Configuration {
         if let Some(v) = command_line.annotation_size_factor {
             self.annotation_size_factor = v;
         }
-        if command_line.save_on_copy {
-            self.save_on_copy = command_line.save_on_copy;
+        if command_line.save_after_copy {
+            self.save_after_copy = command_line.save_after_copy;
         }
     }
 
@@ -209,8 +209,8 @@ impl Configuration {
         self.annotation_size_factor
     }
 
-    pub fn save_on_copy(&self) -> bool {
-        self.save_on_copy
+    pub fn save_after_copy(&self) -> bool {
+        self.save_after_copy
     }
 
     pub fn color_palette(&self) -> &ColorPalette {
@@ -228,7 +228,7 @@ impl Default for Configuration {
             initial_tool: Tools::Pointer,
             copy_command: None,
             annotation_size_factor: 1.0f64,
-            save_on_copy: false,
+            save_after_copy: false,
             color_palette: ColorPalette::default(),
         }
     }
@@ -263,7 +263,7 @@ struct ConfiguationFileGeneral {
     copy_command: Option<String>,
     annotation_size_factor: Option<f64>,
     output_filename: Option<String>,
-    save_on_copy: Option<bool>,
+    save_after_copy: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -144,6 +144,18 @@ impl SketchBoard {
     }
 
     fn handle_save(&self, sender: ComponentSender<Self>) {
+        let texture = match self.renderer.render_to_texture(&self.active_tool) {
+            Ok(t) => t,
+            Err(e) => {
+                println!("Error while creating texture: {e}");
+                return;
+            }
+        };
+
+        self.handle_save_texture(sender, &texture);
+    }
+
+    fn handle_save_texture(&self, sender: ComponentSender<Self>, texture: &MemoryTexture) {
         let output_filename = match APP_CONFIG.read().output_filename() {
             None => {
                 println!("No Output filename specified!");
@@ -163,14 +175,6 @@ impl SketchBoard {
                 .emit(SketchBoardOutput::ShowToast(msg.to_string()));
             return;
         }
-
-        let texture = match self.renderer.render_to_texture(&self.active_tool) {
-            Ok(t) => t,
-            Err(e) => {
-                println!("Error while creating texture: {e}");
-                return;
-            }
-        };
 
         let data = texture.save_to_png_bytes();
 
@@ -236,7 +240,7 @@ impl SketchBoard {
                 ));
 
                 if APP_CONFIG.read().save_on_copy() {
-                    self.handle_save(sender);
+                    self.handle_save_texture(sender, &texture);
                 };
             },
         }

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -239,7 +239,7 @@ impl SketchBoard {
                     "Copied to clipboard.".to_string(),
                 ));
 
-                if APP_CONFIG.read().save_on_copy() {
+                if APP_CONFIG.read().save_after_copy() {
                     self.handle_save_texture(sender, &texture);
                 };
             },

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -242,7 +242,7 @@ impl SketchBoard {
                 if APP_CONFIG.read().save_after_copy() {
                     self.handle_save_texture(sender, &texture);
                 };
-            },
+            }
         }
     }
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -230,9 +230,15 @@ impl SketchBoard {
 
         match result {
             Err(e) => println!("Error saving {e}"),
-            Ok(()) => sender.output_sender().emit(SketchBoardOutput::ShowToast(
-                "Copied to clipboard.".to_string(),
-            )),
+            Ok(()) => {
+                sender.output_sender().emit(SketchBoardOutput::ShowToast(
+                    "Copied to clipboard.".to_string(),
+                ));
+
+                if APP_CONFIG.read().save_on_copy() {
+                    self.handle_save(sender);
+                };
+            },
         }
     }
 


### PR DESCRIPTION
Implementing an option similar to flameshot's setting "Save image after copy"

Motivation: useful with `early-exit = true` so you can view your screenshot later without relying on clipboard manager history, or saving manually, or configuring `copy-command` solely for this