### PR TITLE
Add support for non-latin alphabet

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -162,9 +162,12 @@ impl Component for App {
             // and send the messages there
             add_controller = gtk::EventControllerKey {
                 connect_key_pressed[sketch_board_sender] => move |controller, key, code, modifier | {
-                    let im_context = controller.im_context().unwrap();
-                    im_context.focus_in();
-                    if !im_context.filter_keypress(controller.current_event().unwrap()) {
+                    if let Some(im_context) = controller.im_context() {
+                        im_context.focus_in();
+                        if !im_context.filter_keypress(controller.current_event().unwrap()) {
+                            sketch_board_sender.emit(SketchBoardInput::new_key_event(KeyEventMsg::new(key, code, modifier)));
+                        }
+                    } else {
                         sketch_board_sender.emit(SketchBoardInput::new_key_event(KeyEventMsg::new(key, code, modifier)));
                     }
                     Inhibit(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,6 @@ impl Component for App {
                     let im_context = controller.im_context().unwrap();
                     im_context.focus_in();
                     if !im_context.filter_keypress(controller.current_event().unwrap()) {
-                        println!("key pressed: {:?}", key);
                         sketch_board_sender.emit(SketchBoardInput::new_key_event(KeyEventMsg::new(key, code, modifier)));
                     }
                     Inhibit(false)
@@ -174,7 +173,6 @@ impl Component for App {
                 #[wrap(Some)]
                 set_im_context = &gtk::IMMulticontext {
                     connect_commit[sketch_board_sender] => move |_cx, txt| {
-                        println!("commit: {}", txt.to_string());
                         sketch_board_sender.emit(SketchBoardInput::new_text_event(
                             TextEventMsg::Commit(txt.to_string()),
                         ))


### PR DESCRIPTION
Use IMContext to obtain the output of the input method to support non-Latin characters.

![2024-02-22-20-12-15](https://github.com/gabm/Satty/assets/79776530/54198deb-3bc3-4409-8463-a5278d9d12a5)
