### PR TITLE
fix coordinate remapping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,8 @@
             },
             "args": [
                 "--filename",
-                "/home/gabm/Pictures/Screenshots/satty-20240109-22:19:08.png",
+                "/home/gabm/Pictures/Screenshots/satty-20240219-14:19:29.png",
+                //"/home/gabm/Pictures/Screenshots/satty-20240109-22:19:08.png",
                 //"/home/gabm/Pictures/Wallpaper/torres_1.jpg"
                 "--output-filename",
                 "/tmp/out.png"

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -10,6 +10,7 @@ use relm4::{
 };
 
 use crate::{
+    math::Vec2D,
     sketch_board::{Action, SketchBoardInput},
     tools::{CropTool, Drawable, Tool},
 };
@@ -59,16 +60,20 @@ impl FemtoVGArea {
         self.imp().request_render(action);
     }
 
-    pub fn get_scale_factor(&self) -> f32 {
-        let renderer_scale_factor = self
-            .imp()
+    pub fn abs_canvas_to_image_coordinates(&self, input: Vec2D) -> Vec2D {
+        self.imp()
             .inner()
             .as_mut()
             .expect("Did you call init before using FemtoVgArea?")
-            .get_scale_factor();
-        let dpi_scale_factor = self.scale_factor() as f32;
+            .abs_canvas_to_image_coordinates(input, self.scale_factor() as f32)
+    }
 
-        renderer_scale_factor / dpi_scale_factor
+    pub fn rel_canvas_to_image_coordinates(&self, input: Vec2D) -> Vec2D {
+        self.imp()
+            .inner()
+            .as_mut()
+            .expect("Did you call init before using FemtoVgArea?")
+            .rel_canvas_to_image_coordinates(input, self.scale_factor() as f32)
     }
     pub fn init(
         &mut self,


### PR DESCRIPTION
After the new OpenGL Renderer has been introduced, the coordinate remapping was faulty as shown in #44. This implements a fix to that.

In Future we might think about a different strategy..