### PR TITLE
Fix bug when reading images with stride unequal to width

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,8 @@
             },
             "args": [
                 "--filename",
-                "/home/gabm/Pictures/Screenshots/satty-20240219-14:19:29.png",
+                "/tmp/bug.png",
+                //"/home/gabm/Pictures/Screenshots/satty-20240219-14:19:29.png",
                 //"/home/gabm/Pictures/Screenshots/satty-20240109-22:19:08.png",
                 //"/home/gabm/Pictures/Wallpaper/torres_1.jpg"
                 "--output-filename",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,8 @@
                 "run",
                 "--",
                 "--filename",
-                "/home/gabm/Pictures/Screenshots/satty-20240219-14:19:29.png", // small
+                "/tmp/bug.png",
+                //"/home/gabm/Pictures/Screenshots/satty-20240219-14:19:29.png", // small
                 //"/home/gabm/Pictures/Screenshots/satty-20240109-22:19:08.png", // big
                 //"--fullscreen",
                 "--output-filename",

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -417,8 +417,11 @@ impl FemtoVgAreaMut {
 
             let row_length = width * bytes_per_pixel;
             let mut dst_buffer = if row_length == stride {
+                // stride == row_length, there are no additional bytes after the end of each row
                 src_buffer.to_vec()
             } else {
+                // stride != row_length, there are additional bytes after the end of each row that
+                // need to be truncated. We copy row by row..
                 let mut dst_buffer = Vec::<u8>::with_capacity(width * height * bytes_per_pixel);
 
                 for row in 0..height {
@@ -428,6 +431,8 @@ impl FemtoVgAreaMut {
                 dst_buffer
             };
 
+            // in almost all cases, that should be a no-op. Buf we might have additional elements after the
+            // end of the buffer, e.g. after width * height * bytes_per_pixel
             dst_buffer.truncate(width * height * bytes_per_pixel);
 
             if image.has_alpha() {


### PR DESCRIPTION
since imgref works with stride in pixels, sub-pixel strides cannot be accounted for. This results in bugs like #59 . We now align the strides manually...

Upstream bug has already been reported: https://github.com/kornelski/imgref/issues/23

fixes #59 