### PR TITLE
When the text tool is active, undo does remove other drawables

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -273,7 +273,9 @@ impl SketchBoard {
     }
 
     fn handle_undo(&mut self) -> ToolUpdateResult {
-        if self.renderer.undo() {
+        if self.active_tool.borrow().active() {
+            self.active_tool.borrow_mut().handle_undo()
+        } else if self.renderer.undo() {
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified
@@ -281,7 +283,9 @@ impl SketchBoard {
     }
 
     fn handle_redo(&mut self) -> ToolUpdateResult {
-        if self.renderer.redo() {
+        if self.active_tool.borrow().active() {
+            self.active_tool.borrow_mut().handle_redo()
+        } else if self.renderer.redo() {
             ToolUpdateResult::Redraw
         } else {
             ToolUpdateResult::Unmodified

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -79,6 +79,18 @@ pub trait Tool {
         ToolUpdateResult::Unmodified
     }
 
+    fn active(&self) -> bool {
+        false
+    }
+
+    fn handle_undo(&mut self) -> ToolUpdateResult {
+        ToolUpdateResult::Unmodified
+    }
+
+    fn handle_redo(&mut self) -> ToolUpdateResult {
+        ToolUpdateResult::Unmodified
+    }
+
     fn get_drawable(&self) -> Option<&dyn Drawable>;
 }
 


### PR DESCRIPTION
The undo behaviour is not targeted against the active tool but only against the comitted renderer stack. That leads to unexpected behaviour.

fixes #57 