### PR TITLE
fix gnome dash running app icon

### DIFF
--- a/satty.desktop
+++ b/satty.desktop
@@ -11,3 +11,4 @@ Icon=satty
 Categories=Utility;Graphics;
 StartupNotify=true
 MimeType=image/png;image/jpeg;
+StartupWMClass=com.gabm.satty


### PR DESCRIPTION
before:

![Screenshot from 2024-04-23 08-50-45](https://github.com/gabm/Satty/assets/154056/e2a2fa39-7661-4cef-98e7-091cc567e378)

after:

![Screenshot from 2024-04-23 08-51-27](https://github.com/gabm/Satty/assets/154056/5243f9e5-cef1-4994-97d0-48597180816a)
