### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You first need to install the native dependencies of Satty (see below) and then 
 
 ```sh
 # build release binary, located in ./target/release/satty
-make
+make build-release
 
 # optional: install to /usr/local
 PREFIX=/usr/local make install


### PR DESCRIPTION
So that it builds the release profile instead of the debug one...

I think somewhere along the way the default target was changed from `build-release` to `build`.