### PR TITLE
Fix blur offset

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -1,7 +1,7 @@
 use std::{
     f32::consts::PI,
     fmt::Display,
-    ops::{Add, AddAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, Sub, SubAssign},
 };
 
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
@@ -87,6 +87,14 @@ impl Sub for Vec2D {
 impl SubAssign for Vec2D {
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
+    }
+}
+
+impl Mul<f32> for Vec2D {
+    type Output = Vec2D;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Vec2D::new(self.x * rhs, self.y * rhs)
     }
 }
 

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -31,16 +31,15 @@ impl Blur {
     ) -> Result<ImageId> {
         let img = canvas.screenshot()?;
 
-        // TODO: review that calculation!
-        let scaled_width = canvas.width() as f32 / canvas.transform().average_scale();
-        let dpi = img.width() as f32 / scaled_width;
+        let transformed_pos = canvas.transform().transform_point(pos.x, pos.y);
+        let transformed_size = size * canvas.transform().average_scale();
 
         let (buf, width, height) = img
             .sub_image(
-                (pos.x * dpi) as usize,
-                (pos.y * dpi) as usize,
-                (size.x * dpi) as usize,
-                (size.y * dpi) as usize,
+                transformed_pos.0 as usize,
+                transformed_pos.1 as usize,
+                transformed_size.x as usize,
+                transformed_size.y as usize,
             )
             .to_contiguous_buf();
         let sub = Img::new(buf.into_owned(), width, height);


### PR DESCRIPTION
When the image is displayed at an offset due to resizing, the blurred part of the image is not read from the right location.. fixes #83 