### PR TITLE
suggest to use ppm by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Options:
 You can bind a key to the following command:
 
 ```
-grim -g "$(slurp -o -r -c '#ff0000ff')" - | satty --filename - --fullscreen --output-filename ~/Pictures/Screenshots/satty-$(date '+%Y%m%d-%H:%M:%S').png
+grim -g "$(slurp -o -r -c '#ff0000ff')" -t ppm - | satty --filename - --fullscreen --output-filename ~/Pictures/Screenshots/satty-$(date '+%Y%m%d-%H:%M:%S').png
 ```
 
 ## Build from source


### PR DESCRIPTION
ppm is supported by grim and seems to offer a marginally improved performance. Suggest its usage per default

fixes #78 