### PR TITLE
Execute `copy-command` via system shell

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -232,7 +232,9 @@ impl SketchBoard {
         texture: &impl IsA<Texture>,
         command: &str,
     ) -> anyhow::Result<()> {
-        let mut child = Command::new(command)
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(command)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .spawn()?;


### PR DESCRIPTION
...specifically, `sh`. This allows for commands with arguments, such as `wl-copy -t image/png`, or even more advanced shell features.

This technically also allows for arbitrary command execution, but the user already has execution privileges anyway if they're providing a copy command.

Fixes #105
