### PR TITLE
feat: make color configuration more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,28 @@ disable-notifications = false
 family = "Roboto"
 style = "Bold"
 
-# custom colours for the colour palette
+# Custom colours for the colour palette
 [color-palette]
-first= "#00ffff"
-second= "#a52a2a"
-third= "#dc143c"
-fourth= "#ff1493"
-fifth= "#ffd700"
-custom= "#008000"
+# These will be shown in the toolbar for quick selection
+palette = [
+    "#00ffff",
+    "#a52a2a",
+    "#dc143c",
+    "#ff1493",
+    "#ffd700",
+    "#008000",
+]
+
+# These will be available in the color picker as presets
+# Leave empty to use GTK's default
+custom = [
+    "#00ffff",
+    "#a52a2a",
+    "#dc143c",
+    "#ff1493",
+    "#ffd700",
+    "#008000",
+]
 ```
 
 ### Command Line

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {
@@ -36,11 +18,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1707205916,
-        "narHash": "sha256-fmRJilYGlB7VCt3XsdYxrA0u8e/K84O5xYucerUY0iM=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cc79aa39bbc6eaedaf286ae655b224c71e02907",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -58,35 +40,19 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1706753617,
-        "narHash": "sha256-ZKqTFzhFwSWFEpQTJ0uXnfJBs5Y/po9/8TK4bzssdbs=",
+        "lastModified": 1734661750,
+        "narHash": "sha256-BI58NBdimxu1lnpOrG9XxBz7Cwqy+qIf99zunWofX5w=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "58be43ae223034217ea1bd58c73210644031b687",
+        "rev": "7d3d910d5fd575e6e8c5600d83d54e5c47273bfe",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -71,57 +71,25 @@ impl FontConfiguration {
 }
 
 pub struct ColorPalette {
-    first: Color,
-    second: Color,
-    third: Color,
-    fourth: Color,
-    fifth: Color,
-    custom: Color,
+    palette: Vec<Color>,
+    custom: Vec<Color>,
 }
 
 impl ColorPalette {
-    pub fn first(&self) -> Color {
-        self.first
+    pub fn palette(&self) -> &[Color] {
+        &self.palette
     }
 
-    pub fn second(&self) -> Color {
-        self.second
-    }
-
-    pub fn third(&self) -> Color {
-        self.third
-    }
-
-    pub fn fourth(&self) -> Color {
-        self.fourth
-    }
-
-    pub fn fifth(&self) -> Color {
-        self.fifth
-    }
-
-    pub fn custom(&self) -> Color {
-        self.custom
+    pub fn custom(&self) -> &[Color] {
+        &self.custom
     }
 
     fn merge(&mut self, file_palette: ColorPaletteFile) {
-        if let Some(v) = file_palette.first {
-            self.first = v.into();
-        }
-        if let Some(v) = file_palette.second {
-            self.second = v.into();
-        }
-        if let Some(v) = file_palette.third {
-            self.third = v.into();
-        }
-        if let Some(v) = file_palette.fourth {
-            self.fourth = v.into();
-        }
-        if let Some(v) = file_palette.fifth {
-            self.fifth = v.into();
+        if let Some(v) = file_palette.palette {
+            self.palette = v.into_iter().map(Color::from).collect();
         }
         if let Some(v) = file_palette.custom {
-            self.custom = v.into();
+            self.custom = v.into_iter().map(Color::from).collect();
         }
     }
 }
@@ -314,12 +282,14 @@ impl Default for Configuration {
 impl Default for ColorPalette {
     fn default() -> Self {
         Self {
-            first: Color::orange(),
-            second: Color::red(),
-            third: Color::green(),
-            fourth: Color::blue(),
-            fifth: Color::cove(),
-            custom: Color::pink(),
+            palette: vec![
+                Color::orange(),
+                Color::red(),
+                Color::green(),
+                Color::blue(),
+                Color::cove(),
+            ],
+            custom: vec![],
         }
     }
 }
@@ -357,12 +327,8 @@ struct ConfigurationFileGeneral {
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct ColorPaletteFile {
-    first: Option<HexColor>,
-    second: Option<HexColor>,
-    third: Option<HexColor>,
-    fourth: Option<HexColor>,
-    fifth: Option<HexColor>,
-    custom: Option<HexColor>,
+    palette: Option<Vec<HexColor>>,
+    custom: Option<Vec<HexColor>>,
 }
 
 impl ConfigurationFile {

--- a/src/style.rs
+++ b/src/style.rs
@@ -36,7 +36,13 @@ pub enum Size {
 
 impl Default for Color {
     fn default() -> Self {
-        APP_CONFIG.read().color_palette().first()
+        APP_CONFIG
+            .read()
+            .color_palette()
+            .palette()
+            .first()
+            .copied()
+            .unwrap_or(Color::red())
     }
 }
 

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -529,7 +529,7 @@ impl ToVariant for ColorButtons {
     fn to_variant(&self) -> Variant {
         Variant::from(match *self {
             Self::Palette(i) => i,
-            Self::Custom => std::u64::MAX,
+            Self::Custom => u64::MAX,
         })
     }
 }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -249,12 +249,8 @@ impl SimpleComponent for ToolsToolbar {
 
 #[derive(Debug, Copy, Clone)]
 pub enum ColorButtons {
-    First = 0,
-    Second = 1,
-    Third = 2,
-    Fourth = 3,
-    Fifth = 4,
-    Custom = 5,
+    Palette(u64),
+    Custom,
 }
 
 impl StyleToolbar {
@@ -275,6 +271,23 @@ impl StyleToolbar {
             let dialog = builder.build();
             dialog.set_use_alpha(true);
 
+            let custom_colors = APP_CONFIG
+                .read()
+                .color_palette()
+                .custom()
+                .iter()
+                .copied()
+                .map(RGBA::from)
+                .collect::<Vec<_>>();
+
+            if !custom_colors.is_empty() {
+                dialog.add_palette(
+                    gtk::Orientation::Horizontal,
+                    8, // A more or less arbitrary, but reasonable value.
+                    &custom_colors,
+                );
+            }
+
             // set callback for result
             let dialog_copy = dialog.clone();
             dialog.connect_response(move |_, r| {
@@ -292,11 +305,7 @@ impl StyleToolbar {
     fn map_button_to_color(&self, button: ColorButtons) -> Color {
         let config = APP_CONFIG.read();
         match button {
-            ColorButtons::First => config.color_palette().first(),
-            ColorButtons::Second => config.color_palette().second(),
-            ColorButtons::Third => config.color_palette().third(),
-            ColorButtons::Fourth => config.color_palette().fourth(),
-            ColorButtons::Fifth => config.color_palette().fifth(),
+            ColorButtons::Palette(n) => config.color_palette().palette()[n as usize],
             ColorButtons::Custom => self.custom_color,
         }
     }
@@ -321,46 +330,6 @@ impl Component for StyleToolbar {
             #[watch]
             set_visible: model.visible,
 
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-
-                create_icon(APP_CONFIG.read().color_palette().first()),
-
-                ActionablePlus::set_action::<ColorAction>: ColorButtons::First,
-            },
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-
-                create_icon(APP_CONFIG.read().color_palette().second()),
-
-                ActionablePlus::set_action::<ColorAction>: ColorButtons::Second,
-            },
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-
-                create_icon(APP_CONFIG.read().color_palette().third()),
-
-                ActionablePlus::set_action::<ColorAction>: ColorButtons::Third,
-            },
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-
-                create_icon(APP_CONFIG.read().color_palette().fourth()),
-
-                ActionablePlus::set_action::<ColorAction>: ColorButtons::Fourth
-            },
-            gtk::ToggleButton {
-                set_focusable: false,
-                set_hexpand: false,
-
-                create_icon(APP_CONFIG.read().color_palette().fifth()),
-
-                ActionablePlus::set_action::<ColorAction>: ColorButtons::Fifth,
-            },
             gtk::Separator {},
             gtk::ToggleButton {
                 set_focusable: false,
@@ -463,10 +432,27 @@ impl Component for StyleToolbar {
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        for (i, &color) in APP_CONFIG
+            .read()
+            .color_palette()
+            .palette()
+            .iter()
+            .enumerate()
+            .rev()
+        {
+            let btn = gtk::ToggleButton::builder()
+                .focusable(false)
+                .hexpand(false)
+                .child(&create_icon(color))
+                .build();
+            btn.set_action::<ColorAction>(ColorButtons::Palette(i as u64));
+            root.prepend(&btn);
+        }
+
         // Color Action for selecting colors
         let sender_tmp: ComponentSender<StyleToolbar> = sender.clone();
         let color_action: RelmAction<ColorAction> = RelmAction::new_stateful_with_target_value(
-            &ColorButtons::First,
+            &ColorButtons::Palette(0),
             move |_, state, value| {
                 *state = value;
 
@@ -484,7 +470,13 @@ impl Component for StyleToolbar {
                     .emit(ToolbarEvent::SizeSelected(*state));
             });
 
-        let custom_color = APP_CONFIG.read().color_palette().custom();
+        let custom_color = APP_CONFIG
+            .read()
+            .color_palette()
+            .custom()
+            .first()
+            .copied()
+            .unwrap_or(Color::red());
         let custom_color_pixbuf = create_icon_pixbuf(custom_color);
 
         // create model
@@ -529,26 +521,24 @@ relm4::new_stateful_action!(SizeAction, StyleToolbarActionGroup, "sizes", Size, 
 
 impl StaticVariantType for ColorButtons {
     fn static_variant_type() -> Cow<'static, VariantTy> {
-        Cow::Borrowed(VariantTy::UINT16)
+        Cow::Borrowed(VariantTy::UINT64)
     }
 }
 
 impl ToVariant for ColorButtons {
     fn to_variant(&self) -> Variant {
-        Variant::from(*self as u16)
+        Variant::from(match *self {
+            Self::Palette(i) => i,
+            Self::Custom => std::u64::MAX,
+        })
     }
 }
 
 impl FromVariant for ColorButtons {
     fn from_variant(variant: &Variant) -> Option<Self> {
-        <u16>::from_variant(variant).and_then(|v| match v {
-            0 => Some(ColorButtons::First),
-            1 => Some(ColorButtons::Second),
-            2 => Some(ColorButtons::Third),
-            3 => Some(ColorButtons::Fourth),
-            4 => Some(ColorButtons::Fifth),
-            5 => Some(ColorButtons::Custom),
-            _ => None,
+        <u64>::from_variant(variant).map(|v| match v {
+            std::u64::MAX => Self::Custom,
+            _ => Self::Palette(v),
         })
     }
 }


### PR DESCRIPTION
This refactors the color configuration options such that the user can specify an arbitrary amount of colors for the toolbar, and also specify colors as presets for the color picker. I took the liberty to implement this without prior feedback, sorry :D
![image](https://github.com/user-attachments/assets/b4e34151-775a-4b18-b5bb-872472e94fc7)

Closes #135 