### PR TITLE
Draw a fuller arrow

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -10,6 +10,38 @@ pub struct Vec2D {
     pub y: f32,
 }
 
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct Angle {
+    pub radians: f32,
+}
+impl Angle {
+    pub fn from_radians(radians: f32) -> Self {
+        Self { radians }
+    }
+
+    pub fn from_degrees(degrees: f32) -> Self {
+        Self {
+            radians: degrees * PI / 180.0,
+        }
+    }
+
+    pub fn cos(&self) -> f32 {
+        self.radians.cos()
+    }
+
+    pub fn sin(&self) -> f32 {
+        self.radians.sin()
+    }
+}
+
+impl Mul<f32> for Angle {
+    type Output = Angle;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Angle::from_radians(self.radians * rhs)
+    }
+}
+
 impl Vec2D {
     pub fn zero() -> Self {
         Self { x: 0.0, y: 0.0 }
@@ -25,6 +57,24 @@ impl Vec2D {
 
     pub fn norm2(&self) -> f32 {
         self.x * self.x + self.y * self.y
+    }
+
+    /**
+     * Get the angle of the vector.
+     * Angle of 0 is the positive x-axis.
+     * Angle of PI/2 is the positive y-axis.
+     */
+    pub fn angle(&self) -> Angle {
+        Angle::from_radians(self.y.atan2(self.x))
+    }
+
+    /**
+     * Create a vector from an angle.
+     * Angle of 0 is the positive x-axis.
+     * Angle of PI/2 is the positive y-axis.
+     */
+    pub fn from_angle(angle: Angle) -> Vec2D {
+        Vec2D::new(angle.cos(), angle.sin())
     }
 
     pub fn snapped_vector_15deg(&self) -> Vec2D {

--- a/src/style.rs
+++ b/src/style.rs
@@ -203,6 +203,24 @@ impl Size {
         }
     }
 
+    pub fn to_arrow_tail_width(self) -> f32 {
+        let size_factor = APP_CONFIG.read().annotation_size_factor();
+        match self {
+            Size::Small => 3.0 * size_factor,
+            Size::Medium => 10.0 * size_factor,
+            Size::Large => 25.0 * size_factor,
+        }
+    }
+
+    pub fn to_arrow_head_length(self) -> f32 {
+        let size_factor = APP_CONFIG.read().annotation_size_factor();
+        match self {
+            Size::Small => 15.0 * size_factor,
+            Size::Medium => 30.0 * size_factor,
+            Size::Large => 60.0 * size_factor,
+        }
+    }
+
     pub fn to_blur_factor(self) -> f32 {
         let size_factor = APP_CONFIG.read().annotation_size_factor();
         match self {


### PR DESCRIPTION
The current arrow is composed of 3 thin lines. It would be nice to have a more fatter arrow, so that the individual lines of the arrow aren't as prominent.

The arrow looked like:

![image](https://github.com/user-attachments/assets/45f667fd-d9d6-4cd4-bed3-45d9b94bfc41)

(from small to large, unfilled first, then filled)

Now they look like:

![image](https://github.com/user-attachments/assets/9798bf90-db0f-4e03-b327-40dd9eef9855)
