### PR TITLE
Action (save) on Enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ copy-command = "wl-copy"
 annotation-size-factor = 2
 # Filename to use for saving action. Omit to disable saving to file. Might contain format specifiers: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
+# Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
+action-on-enter = "save-to-clipboard"
 # After copying the screenshot, save it to a file as well
 save-after-copy = false
 # Hide toolbars by default
@@ -139,6 +141,8 @@ Options:
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
           Increase or decrease the size of the annotations
+      --action-on-enter <ACTION_ON_ENTER>
+          Action to perform when pressing Enter [possible values: save-to-clipboard, save-to-file]
       --save-after-copy
           After copying the screenshot, save it to a file as well
   -d, --default-hide-toolbars

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,8 @@ copy-command = "wl-copy"
 annotation-size-factor = 2
 # Filename to use for saving action. Omit to disable saving to file. Might contain format specifiers: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
+# Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
+action-on-enter = "save-to-clipboard"
 # After copying the screenshot, save it to a file as well
 save-after-copy = false
 # Hide toolbars by default

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -41,6 +41,10 @@ pub struct CommandLine {
     #[arg(long)]
     pub annotation_size_factor: Option<f32>,
 
+    /// Action to perform when pressing Enter
+    #[arg(long)]
+    pub action_on_enter: Option<Action>,
+
     /// After copying the screenshot, save it to a file as well
     #[arg(long)]
     pub save_after_copy: bool,
@@ -80,6 +84,13 @@ pub enum Tools {
     Blur,
     Highlight,
     Brush,
+}
+
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum Action {
+    #[default]
+    SaveToClipboard,
+    SaveToFile,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -19,8 +19,9 @@ use relm4::{gtk, Sender};
 use resource::resource;
 
 use crate::{
+    configuration::Action,
     math::Vec2D,
-    sketch_board::{Action, SketchBoardInput},
+    sketch_board::SketchBoardInput,
     tools::{CropTool, Drawable, Tool},
     APP_CONFIG,
 };

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -10,8 +10,9 @@ use relm4::{
 };
 
 use crate::{
+    configuration::Action,
     math::Vec2D,
-    sketch_board::{Action, SketchBoardInput},
+    sketch_board::SketchBoardInput,
     tools::{CropTool, Drawable, Tool},
 };
 

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -444,6 +444,7 @@ impl Component for SketchBoard {
                         ToolUpdateResult::Unmodified
                     } else if ke.key == Key::Return || ke.key == Key::KP_Enter {
                         // First, let the tool handle the event. If the tool does nothing, we can do our thing (otherwise require a second Enter)
+                        // Relying on ToolUpdateResult::Unmodified is probably not a good idea, but it's the only way at the moment. See discussion in #144
                         let result: ToolUpdateResult = self
                             .active_tool
                             .borrow_mut()

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -444,9 +444,13 @@ impl Component for SketchBoard {
                         ToolUpdateResult::Unmodified
                     } else if ke.key == Key::Return || ke.key == Key::KP_Enter {
                         // First, let the tool handle the event. If the tool does nothing, we can do our thing (otherwise require a second Enter)
-                        let result: ToolUpdateResult = self.active_tool.borrow_mut().handle_event(ToolEvent::Input(ie));
+                        let result: ToolUpdateResult = self
+                            .active_tool
+                            .borrow_mut()
+                            .handle_event(ToolEvent::Input(ie));
                         if let ToolUpdateResult::Unmodified = result {
-                            self.renderer.request_render(APP_CONFIG.read().action_on_enter());
+                            self.renderer
+                                .request_render(APP_CONFIG.read().action_on_enter());
                         }
                         result
                     } else {


### PR DESCRIPTION
Other screenshot GUIs like Flameshot allow pressing the Enter key to quickly accept the current selection and save (and possibly close if configured to do so). This PR adds this behavior.

The user can choose which action to take with the new config "action-on-enter" (possible values: `save-to-clipboard`, `save-to-file`).
The default is `save-to-clipboard` (I can change it if you prefer). I also considered making it an Option and defaulting to None (doing nothing when pressing Enter unless configured), but I think it's more intuitive to have the Enter key do something by default.