### PR TITLE
Crop improvements

### DIFF
--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -283,7 +283,7 @@ impl FemtoVgAreaMut {
             .crop_tool
             .borrow()
             .get_crop()
-            .and_then(|c| c.get_rectangle())
+            .map(|c| c.get_rectangle())
             .unwrap_or((
                 Vec2D::zero(),
                 Vec2D::new(

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -19,7 +19,7 @@ use relm4::{gtk, Sender};
 use resource::resource;
 
 use crate::{
-    math::Vec2D,
+    math::{rect_ensure_in_bounds, Vec2D},
     sketch_board::{Action, SketchBoardInput},
     tools::{CropTool, Drawable, Tool},
     APP_CONFIG,
@@ -278,12 +278,13 @@ impl FemtoVgAreaMut {
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         font: FontId,
     ) -> anyhow::Result<ImgVec<RGBA8>> {
+        let bounds = (Vec2D::zero(), Vec2D::new(self.background_image.width() as f32, self.background_image.height() as f32));
         // get offset and size of the area in question
         let (pos, size) = self
             .crop_tool
             .borrow()
             .get_crop()
-            .map(|c| c.get_rectangle())
+            .map(|c| rect_ensure_in_bounds(c.get_rectangle(), bounds))
             .unwrap_or((
                 Vec2D::zero(),
                 Vec2D::new(

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -291,15 +291,11 @@ impl FemtoVgAreaMut {
             .crop_tool
             .borrow()
             .get_crop()
-            .map(|c| rect_ensure_in_bounds(c.get_rectangle(), bounds))
+            .map(|c| c.get_rectangle())
+            .map(|rect| rect_ensure_in_bounds(rect, bounds))
             .map(rect_round)
-            .unwrap_or((
-                Vec2D::zero(),
-                Vec2D::new(
-                    self.background_image.width() as f32,
-                    self.background_image.height() as f32,
-                ),
-            ));
+            .filter(|(_, size)| !size.is_zero())
+            .unwrap_or(bounds);
 
         // create render-target
         let image_id = canvas.create_image_empty(

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -278,7 +278,13 @@ impl FemtoVgAreaMut {
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
         font: FontId,
     ) -> anyhow::Result<ImgVec<RGBA8>> {
-        let bounds = (Vec2D::zero(), Vec2D::new(self.background_image.width() as f32, self.background_image.height() as f32));
+        let bounds = (
+            Vec2D::zero(),
+            Vec2D::new(
+                self.background_image.width() as f32,
+                self.background_image.height() as f32,
+            ),
+        );
         // get offset and size of the area in question
         let (pos, size) = self
             .crop_tool

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -19,7 +19,7 @@ use relm4::{gtk, Sender};
 use resource::resource;
 
 use crate::{
-    math::{rect_ensure_in_bounds, Vec2D},
+    math::{rect_ensure_in_bounds, rect_round, Vec2D},
     sketch_board::{Action, SketchBoardInput},
     tools::{CropTool, Drawable, Tool},
     APP_CONFIG,
@@ -285,6 +285,7 @@ impl FemtoVgAreaMut {
             .borrow()
             .get_crop()
             .map(|c| rect_ensure_in_bounds(c.get_rectangle(), bounds))
+            .map(rect_round)
             .unwrap_or((
                 Vec2D::zero(),
                 Vec2D::new(

--- a/src/math.rs
+++ b/src/math.rs
@@ -119,3 +119,27 @@ pub fn rect_ensure_positive_size(pos: Vec2D, size: Vec2D) -> (Vec2D, Vec2D) {
 
     (Vec2D::new(pos_x, pos_y), Vec2D::new(size_x, size_y))
 }
+
+pub fn rect_ensure_in_bounds(rect: (Vec2D, Vec2D), bounds: (Vec2D, Vec2D)) -> (Vec2D, Vec2D) {
+    let (mut pos, mut size) = rect;
+
+    if pos.x < bounds.0.x {
+        pos.x = bounds.0.x;
+        size.x -= bounds.0.x - pos.x;
+    }
+
+    if pos.y < bounds.0.y {
+        pos.y = bounds.0.y;
+        size.y -= bounds.0.y - pos.y;
+    }
+
+    if pos.x + size.x > bounds.1.x {
+        size.x = bounds.1.x - pos.x;
+    }
+
+    if pos.y + size.y > bounds.1.y {
+        size.y = bounds.1.y - pos.y;
+    }
+
+    (pos, size)
+}

--- a/src/math.rs
+++ b/src/math.rs
@@ -54,6 +54,10 @@ impl Vec2D {
             Vec2D::new(-a, -b)
         }
     }
+
+    pub fn is_zero(&self) -> bool {
+        self.x.abs() < f32::EPSILON && self.y.abs() < f32::EPSILON
+    }
 }
 
 impl Add for Vec2D {

--- a/src/math.rs
+++ b/src/math.rs
@@ -143,3 +143,14 @@ pub fn rect_ensure_in_bounds(rect: (Vec2D, Vec2D), bounds: (Vec2D, Vec2D)) -> (V
 
     (pos, size)
 }
+
+pub fn rect_round(rect: (Vec2D, Vec2D)) -> (Vec2D, Vec2D) {
+    let (mut pos, mut size) = rect;
+
+    pos.x = pos.x.round();
+    pos.y = pos.y.round();
+    size.x = size.x.round();
+    size.y = size.y.round();
+
+    (pos, size)
+}

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -28,7 +28,11 @@ impl Crop {
     const HANDLE_BORDER: f32 = 2.0;
 
     fn new(pos: Vec2D) -> Self {
-        Self { pos, size: Vec2D::zero(), active: true }
+        Self {
+            pos,
+            size: Vec2D::zero(),
+            active: true,
+        }
     }
 
     fn draw_single_handle(
@@ -89,8 +93,11 @@ impl Crop {
         let allowed_distance2 = HANDLE_SIZE2 + margin2;
 
         let (handle, distance2) = self.get_closest_handle(mouse_pos);
-        if distance2 < allowed_distance2 { Some(handle) }
-        else { None }
+        if distance2 < allowed_distance2 {
+            Some(handle)
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
Improvements:

- NEW: Dragging outside the area will create a new crop (previously did nothing)
    - Useful for starting again after a misclick

https://github.com/user-attachments/assets/bfdc24ff-4470-480f-8661-2bf29efa2183


- Dragging outside the area (but close to the region) will search the closest handle and act as if that handle had been clicked
    - Prevents accidentally losing the current selection (accidentally starting a new crop)

https://github.com/user-attachments/assets/581c47aa-a6a0-49f7-abac-5e90ddab5a29


- Dragging inside the area moves it (unchanged behavior)

- NEW: Dragging inside the area while very close to a handle will act as if that handle had been clicked
    - Prevents losing the area placement when misclicking a handle

https://github.com/user-attachments/assets/c42d0793-03f4-4629-a245-07e15ef133f2


- By clicking the area and moving it, it is possible to have a part of the area outside the bounds of the image. This previously resulted in a black background in the out-of-bounds area, while now it is excluded.

https://github.com/user-attachments/assets/14d073a1-85ff-460d-90e3-83b0b2cb5247

| Old | New |
|---|---|
| ![n6](https://github.com/user-attachments/assets/04279a24-f00c-4433-ba69-9c89b574a703) | ![n5](https://github.com/user-attachments/assets/552dcace-5fca-44e5-9c2b-4bd123fbe3f6) |

- Due to the use of floats, using the crop tool could result in the image looking blurry. The crop is now rounded to the closest integer to avoid that issue.

| Old | New |
|---|---|
| ![n8](https://github.com/user-attachments/assets/47a2b703-3291-40cb-8400-8a3fbf650de3) | ![n7](https://github.com/user-attachments/assets/a068edac-2531-4d09-b89f-47e60073bf0a) |
| ![image](https://github.com/user-attachments/assets/08820ce8-84eb-4608-86d8-7fd3556fea6f) | ![image](https://github.com/user-attachments/assets/ea6a71aa-a904-4fd7-bdd4-c5a3fa6bb9ef) |

- The PR also has some minor code cleanup in `crop.rs`, mostly to move some methods that made more sense in Crop than CropTool and to make Crop.size not an Option (didn't seem necessary and also caused some minor flickering).
