### PR TITLE
Add toolbar keyboard shortcuts

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -6,6 +6,7 @@ use gdk_pixbuf::glib::Bytes;
 use gdk_pixbuf::Pixbuf;
 use keycode::{KeyMap, KeyMappingId};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -21,7 +22,7 @@ use crate::femtovg_area::FemtoVGArea;
 use crate::math::Vec2D;
 use crate::notification::log_result;
 use crate::style::Style;
-use crate::tools::{Tool, ToolEvent, ToolUpdateResult, ToolsManager};
+use crate::tools::{Tool, ToolEvent, ToolUpdateResult, Tools, ToolsManager};
 use crate::ui::toolbars::ToolbarEvent;
 
 type RenderedImage = Img<Vec<RGBA<u8>>>;
@@ -31,11 +32,13 @@ pub enum SketchBoardInput {
     InputEvent(InputEvent),
     ToolbarEvent(ToolbarEvent),
     RenderResult(RenderedImage, Action),
+    CommitEvent(TextEventMsg),
 }
 
 #[derive(Debug, Clone)]
 pub enum SketchBoardOutput {
     ToggleToolbarsDisplay,
+    ToolSwitchShortcut(Tools),
 }
 
 #[derive(Debug, Clone)]
@@ -107,6 +110,10 @@ impl SketchBoardInput {
 
     pub fn new_text_event(event: TextEventMsg) -> SketchBoardInput {
         SketchBoardInput::InputEvent(InputEvent::Text(event))
+    }
+
+    pub fn new_commit_event(event: TextEventMsg) -> SketchBoardInput {
+        SketchBoardInput::CommitEvent(event)
     }
 }
 
@@ -365,6 +372,68 @@ impl SketchBoard {
             }
         }
     }
+
+    fn handle_text_commit(
+        &self,
+        event: TextEventMsg,
+        sender: ComponentSender<Self>,
+    ) -> ToolUpdateResult {
+        let tool_shortcuts = HashMap::from([
+            (("p", ""), Tools::Pointer),
+            (("c", "1"), Tools::Crop),
+            (("b", "2"), Tools::Brush),
+            (("l", "3"), Tools::Line),
+            (("a", "4"), Tools::Arrow),
+            (("r", "5"), Tools::Rectangle),
+            (("e", "6"), Tools::Ellipse),
+            (("t", "7"), Tools::Text),
+            (("m", "8"), Tools::Marker),
+            (("u", "9"), Tools::Blur),
+            (("h", "0"), Tools::Highlight),
+        ]);
+        match event {
+            TextEventMsg::Commit(txt) => {
+                // NOTE:
+                // If there's an IMContext binded to the controller, single letter-key events will
+                // always go through it first, denying a bypass, so the only way we can do single-key
+                // bindings is to act upon the IMMulticontext's commit event itself.
+                // NOTE:
+                // Here we're basically bypassing the IMMulticontext. If the text tool is active
+                // and wants text inputs, we're interested in the single-letter keypress as a text character.
+                // If not, we parse it as a shortcut event.
+                if self.active_tool_type() == Tools::Text
+                    && self.active_tool.borrow().input_enabled()
+                {
+                    sender.input(SketchBoardInput::new_text_event(TextEventMsg::Commit(
+                        txt.to_string(),
+                    )));
+                    ToolUpdateResult::Unmodified
+                } else {
+                    let key = txt.as_str();
+                    if let Some(tool) = tool_shortcuts
+                        .iter()
+                        .find(|item| item.0.0 == key || item.0.1 == key)
+                        .map(|(_, tool)| tool)
+                    {
+                        sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::ToolSelected(
+                            *tool,
+                        )));
+                        sender
+                            .output_sender()
+                            .emit(SketchBoardOutput::ToolSwitchShortcut(*tool));
+
+                        ToolUpdateResult::Unmodified
+                    } else {
+                        ToolUpdateResult::Unmodified
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn active_tool_type(&self) -> Tools {
+        self.active_tool.borrow().get_tool_type()
+    }
 }
 
 #[relm4::component(pub)]
@@ -380,6 +449,8 @@ impl Component for SketchBoard {
             area -> FemtoVGArea {
                 set_vexpand: true,
                 set_hexpand: true,
+                set_can_focus: true,
+                set_focusable: true,
                 grab_focus: (),
 
                 add_controller = gtk::GestureDrag {
@@ -418,6 +489,38 @@ impl Component for SketchBoard {
                             Vec2D::new(x as f32, y as f32)));
                     }
                 },
+
+                add_controller = gtk::EventControllerKey {
+                    connect_key_pressed[sender] => move |controller, key, code, modifier | {
+                        if let Some(im_context) = controller.im_context() {
+                            im_context.focus_in();
+                            if !im_context.filter_keypress(controller.current_event().unwrap()) {
+                                sender.input(SketchBoardInput::new_key_event(KeyEventMsg::new(key, code, modifier)));
+                            }
+                        } else {
+                            sender.input(SketchBoardInput::new_key_event(KeyEventMsg::new(key, code, modifier)));
+                        }
+                        glib::Propagation::Stop
+                    },
+
+                    connect_key_released[sender] => move |controller, key, code, modifier | {
+                        if let Some(im_context) = controller.im_context() {
+                            im_context.focus_in();
+                            if !im_context.filter_keypress(controller.current_event().unwrap()) {
+                                sender.input(SketchBoardInput::new_key_release_event(KeyEventMsg::new(key, code, modifier)));
+                            }
+                        } else {
+                            sender.input(SketchBoardInput::new_key_release_event(KeyEventMsg::new(key, code, modifier)));
+                        }
+                    },
+
+                    #[wrap(Some)]
+                    set_im_context = &gtk::IMMulticontext {
+                        connect_commit[sender] => move |_cx, txt| {
+                            sender.input(SketchBoardInput::new_commit_event(TextEventMsg::Commit(txt.to_string())));
+                        },
+                    },
+                }
             }
         },
     }
@@ -427,48 +530,57 @@ impl Component for SketchBoard {
         let result = match msg {
             SketchBoardInput::InputEvent(mut ie) => {
                 if let InputEvent::Key(ke) = ie {
-                    if ke.is_one_of(Key::z, KeyMappingId::UsZ)
-                        && ke.modifier == ModifierType::CONTROL_MASK
-                    {
-                        self.handle_undo()
-                    } else if ke.is_one_of(Key::y, KeyMappingId::UsY)
-                        && ke.modifier == ModifierType::CONTROL_MASK
-                    {
-                        self.handle_redo()
-                    } else if ke.is_one_of(Key::t, KeyMappingId::UsT)
-                        && ke.modifier == ModifierType::CONTROL_MASK
-                    {
-                        self.handle_toggle_toolbars_display(sender)
-                    } else if ke.is_one_of(Key::s, KeyMappingId::UsS)
-                        && ke.modifier == ModifierType::CONTROL_MASK
-                    {
-                        self.renderer.request_render(Action::SaveToFile);
-                        ToolUpdateResult::Unmodified
-                    } else if ke.is_one_of(Key::c, KeyMappingId::UsC)
-                        && ke.modifier == ModifierType::CONTROL_MASK
-                    {
-                        self.renderer.request_render(Action::SaveToClipboard);
-                        ToolUpdateResult::Unmodified
-                    } else if ke.key == Key::Escape {
-                        relm4::main_application().quit();
-                        // this is only here to make rust happy. The application should exit with the previous call
-                        ToolUpdateResult::Unmodified
-                    } else if ke.key == Key::Return || ke.key == Key::KP_Enter {
-                        // First, let the tool handle the event. If the tool does nothing, we can do our thing (otherwise require a second Enter)
-                        // Relying on ToolUpdateResult::Unmodified is probably not a good idea, but it's the only way at the moment. See discussion in #144
-                        let result: ToolUpdateResult = self
-                            .active_tool
-                            .borrow_mut()
-                            .handle_event(ToolEvent::Input(ie));
-                        if let ToolUpdateResult::Unmodified = result {
-                            self.renderer
-                                .request_render(APP_CONFIG.read().action_on_enter());
+                    match (true, ke.modifier) {
+                        (z, ModifierType::CONTROL_MASK)
+                            if z == ke.is_one_of(Key::z, KeyMappingId::UsZ) =>
+                        {
+                            self.handle_undo()
                         }
-                        result
-                    } else {
-                        self.active_tool
-                            .borrow_mut()
-                            .handle_event(ToolEvent::Input(ie))
+                        (y, ModifierType::CONTROL_MASK)
+                            if y == ke.is_one_of(Key::y, KeyMappingId::UsY) =>
+                        {
+                            self.handle_redo()
+                        }
+                        (t, ModifierType::CONTROL_MASK)
+                            if t == ke.is_one_of(Key::t, KeyMappingId::UsT) =>
+                        {
+                            self.handle_toggle_toolbars_display(sender)
+                        }
+                        (s, ModifierType::CONTROL_MASK)
+                            if s == ke.is_one_of(Key::s, KeyMappingId::UsS) =>
+                        {
+                            self.renderer.request_render(Action::SaveToFile);
+                            ToolUpdateResult::Unmodified
+                        }
+                        (c, ModifierType::CONTROL_MASK)
+                            if c == ke.is_one_of(Key::c, KeyMappingId::UsC) =>
+                        {
+                            self.renderer.request_render(Action::SaveToClipboard);
+                            ToolUpdateResult::Unmodified
+                        }
+                        (esc, _) if esc == ke.is_one_of(Key::Escape, KeyMappingId::Escape) => {
+                            relm4::main_application().quit();
+                            // this is only here to make rust happy. The application should exit with the previous call
+                            ToolUpdateResult::Unmodified
+                        }
+                        (enter, _)
+                            if enter
+                                == ke.is_one_of(Key::Return, KeyMappingId::Enter)
+                                    | ke.is_one_of(Key::KP_Enter, KeyMappingId::Enter) =>
+                        {
+                            // First, let the tool handle the event. If the tool does nothing, we can do our thing (otherwise require a second Enter)
+                            // Relying on ToolUpdateResult::Unmodified is probably not a good idea, but it's the only way at the moment. See discussion in #144
+                            let result: ToolUpdateResult = self
+                                .active_tool
+                                .borrow_mut()
+                                .handle_event(ToolEvent::Input(ie));
+                            if let ToolUpdateResult::Unmodified = result {
+                                self.renderer
+                                    .request_render(APP_CONFIG.read().action_on_enter());
+                            }
+                            result
+                        }
+                        _ => ToolUpdateResult::Unmodified,
                     }
                 } else {
                     ie.remap_event_coordinates(&self.renderer);
@@ -482,6 +594,10 @@ impl Component for SketchBoard {
             }
             SketchBoardInput::RenderResult(img, action) => {
                 self.handle_render_result(img, action);
+                ToolUpdateResult::Unmodified
+            }
+            SketchBoardInput::CommitEvent(txt) => {
+                self.handle_text_commit(txt, sender);
                 ToolUpdateResult::Unmodified
             }
         };

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Arrow {
@@ -21,9 +21,22 @@ pub struct Arrow {
 pub struct ArrowTool {
     arrow: Option<Arrow>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for ArrowTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Arrow
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -12,7 +12,7 @@ use crate::{
     style::{Size, Style},
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Debug)]
 pub struct Blur {
@@ -133,9 +133,22 @@ impl Drawable for Blur {
 pub struct BlurTool {
     blur: Option<Blur>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for BlurTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Blur
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -6,12 +6,13 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Default)]
 pub struct BrushTool {
     drawable: Option<BrushDrawable>,
     style: Style,
+    input_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +45,18 @@ impl Drawable for BrushDrawable {
 }
 
 impl Tool for BrushTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Brush
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use femtovg::{Color, Paint, Path};
 use relm4::gtk::gdk::Key;
 
-use super::{Drawable, Tool, ToolUpdateResult};
+use super::{Drawable, Tool, ToolUpdateResult, Tools};
 
 #[derive(Debug, Clone)]
 pub struct Crop {
@@ -21,6 +21,7 @@ pub struct Crop {
 pub struct CropTool {
     crop: Option<Crop>,
     action: Option<CropToolAction>,
+    input_enabled: bool,
 }
 
 impl Crop {
@@ -361,6 +362,18 @@ impl CropTool {
 }
 
 impl Tool for CropTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Crop
+    }
+
     fn handle_key_event(&mut self, event: KeyEventMsg) -> ToolUpdateResult {
         if event.key == Key::Escape && self.crop.is_some() {
             self.handle_deactivated()

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Ellipse {
@@ -47,9 +47,22 @@ impl Drawable for Ellipse {
 pub struct EllipseTool {
     ellipse: Option<Ellipse>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for EllipseTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Ellipse
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         match event.type_ {

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -15,7 +15,7 @@ use crate::{
     tools::DrawableClone,
 };
 
-use super::{Drawable, Tool, ToolUpdateResult};
+use super::{Drawable, Tool, ToolUpdateResult, Tools};
 
 const HIGHLIGHT_OPACITY: f64 = 0.4;
 
@@ -129,6 +129,7 @@ enum HighlightKind {
 pub struct HighlightTool {
     highlighter: Option<HighlightKind>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Drawable for HighlightKind {
@@ -145,6 +146,18 @@ impl Drawable for HighlightKind {
 }
 
 impl Tool for HighlightTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Highlight
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         let ctrl_pressed = event.modifier.intersects(ModifierType::CONTROL_MASK);

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -8,12 +8,13 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Default)]
 pub struct LineTool {
     line: Option<Line>,
     style: Style,
+    input_enabled: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -49,6 +50,14 @@ impl Drawable for Line {
 }
 
 impl Tool for LineTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {
@@ -117,5 +126,9 @@ impl Tool for LineTool {
             Some(d) => Some(d),
             None => None,
         }
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Line
     }
 }

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -8,11 +8,12 @@ use crate::sketch_board::{MouseButton, MouseEventType};
 use crate::style::Style;
 use crate::{math::Vec2D, sketch_board::MouseEventMsg};
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 pub struct MarkerTool {
     style: Style,
     next_number: Rc<RefCell<u16>>,
+    input_enabled: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -84,6 +85,18 @@ impl Drawable for Marker {
 }
 
 impl Tool for MarkerTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Marker
+    }
+
     fn get_drawable(&self) -> Option<&dyn Drawable> {
         None
     }
@@ -122,6 +135,7 @@ impl Default for MarkerTool {
         Self {
             style: Default::default(),
             next_number: Rc::new(RefCell::new(1)),
+            input_enabled: true
         }
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -91,6 +91,10 @@ pub trait Tool {
         false
     }
 
+    fn input_enabled(&self) -> bool;
+
+    fn set_input_enabled(&mut self, value: bool);
+
     fn handle_undo(&mut self) -> ToolUpdateResult {
         ToolUpdateResult::Unmodified
     }
@@ -100,6 +104,8 @@ pub trait Tool {
     }
 
     fn get_drawable(&self) -> Option<&dyn Drawable>;
+
+    fn get_tool_type(&self) -> Tools;
 }
 
 // the clone method below has been adapted from: https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -1,10 +1,24 @@
-use super::Tool;
+use super::{Tool, Tools};
 
 #[derive(Default)]
-pub struct PointerTool {}
+pub struct PointerTool {
+    input_enabled: bool,
+}
 
 impl Tool for PointerTool {
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Pointer
+    }
+
     fn get_drawable(&self) -> Option<&dyn super::Drawable> {
         None
+    }
+
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
     }
 }

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -9,7 +9,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Rectangle {
@@ -54,9 +54,18 @@ impl Drawable for Rectangle {
 pub struct RectangleTool {
     rectangle: Option<Rectangle>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for RectangleTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         match event.type_ {
@@ -138,5 +147,9 @@ impl Tool for RectangleTool {
             Some(d) => Some(d),
             None => None,
         }
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Rectangle
     }
 }

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -13,7 +13,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Debug)]
 pub struct Text {
@@ -155,9 +155,22 @@ impl Drawable for Text {
 pub struct TextTool {
     text: Option<Text>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for TextTool {
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Text
+    }
+
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn get_drawable(&self) -> Option<&dyn Drawable> {
         match &self.text {
             Some(d) => Some(d),
@@ -198,6 +211,7 @@ impl Tool for TextTool {
                     t.editing = false;
                     let result = t.clone_box();
                     self.text = None;
+                    self.input_enabled = false;
                     return ToolUpdateResult::Commit(result);
                 }
             } else if event.key == Key::Escape {
@@ -290,8 +304,11 @@ impl Tool for TextTool {
                     // create a new Text
                     self.text = Some(Text::new(event.pos, self.style));
 
+                    self.set_input_enabled(true);
+
                     return_value
                 } else {
+                    self.set_input_enabled(false);
                     ToolUpdateResult::Unmodified
                 }
             }


### PR DESCRIPTION
Hi folks, this is my very first community PR ever, and I'm also doing this to learn Rust, so bear that in mind.

## Description
This PR introduces changes to allow tool selection via keyboard shorcuts and closes https://github.com/gabm/Satty/issues/50.

| Tool      | Shortcut |
|-----------|----------|
| Pointer   | Alt+P    |
| Crop      | Alt+C    |
| Brush     | Alt+B    |
| Line      | Alt+L    |
| Arrow     | Alt+A    |
| Rectangle | Alt+R    |
| Ellipse   | Alt+E    |
| Text      | Alt+T    |
| Marker    | Alt+M    |
| Blur      | Alt+U    |
| Highlight | Alt+H    |

This is the event flow I came up with. The mouse click also updates the toolbar UI `active_button` so that you don't have two buttons in the UI selected at the same time (one from keyboard and another from a click).

![satty-20250102-01:36:50](https://github.com/user-attachments/assets/02994246-dbfb-4698-bec4-c2ac2919738c)

## Changes made:
Adds keyboard shortcuts functionality to the editing tools

## Notes
- I took the opportunity to refactor the input keys handling on `sketch_board.rs`.
- The `tool_shortcuts` hashmap was defined inside the `update()` method of the `SketchBoard` component for skill issue reasons. I'd like to know how to improve that.
- I'm sure there are many improvements to be made and I don't know if my approach is the best, I'm a total Rust noob. Upon testing everything seems fine, but I'd be surprised if no bugs were introduced. I'd like to know your thoughts on this.