### PR TITLE
feat: single-key and number-key toolbar shortcuts

### DIFF
--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Arrow {
@@ -21,9 +21,22 @@ pub struct Arrow {
 pub struct ArrowTool {
     arrow: Option<Arrow>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for ArrowTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Arrow
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -12,7 +12,7 @@ use crate::{
     style::{Size, Style},
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Debug)]
 pub struct Blur {
@@ -133,9 +133,22 @@ impl Drawable for Blur {
 pub struct BlurTool {
     blur: Option<Blur>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for BlurTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Blur
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -6,12 +6,13 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Default)]
 pub struct BrushTool {
     drawable: Option<BrushDrawable>,
     style: Style,
+    input_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +45,18 @@ impl Drawable for BrushDrawable {
 }
 
 impl Tool for BrushTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Brush
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use femtovg::{Color, Paint, Path};
 use relm4::gtk::gdk::Key;
 
-use super::{Drawable, Tool, ToolUpdateResult};
+use super::{Drawable, Tool, ToolUpdateResult, Tools};
 
 #[derive(Debug, Clone)]
 pub struct Crop {
@@ -21,6 +21,7 @@ pub struct Crop {
 pub struct CropTool {
     crop: Option<Crop>,
     action: Option<CropToolAction>,
+    input_enabled: bool,
 }
 
 impl Crop {
@@ -361,6 +362,18 @@ impl CropTool {
 }
 
 impl Tool for CropTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Crop
+    }
+
     fn handle_key_event(&mut self, event: KeyEventMsg) -> ToolUpdateResult {
         if event.key == Key::Escape && self.crop.is_some() {
             self.handle_deactivated()

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Ellipse {
@@ -47,9 +47,22 @@ impl Drawable for Ellipse {
 pub struct EllipseTool {
     ellipse: Option<Ellipse>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for EllipseTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Ellipse
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         match event.type_ {

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -15,7 +15,7 @@ use crate::{
     tools::DrawableClone,
 };
 
-use super::{Drawable, Tool, ToolUpdateResult};
+use super::{Drawable, Tool, ToolUpdateResult, Tools};
 
 const HIGHLIGHT_OPACITY: f64 = 0.4;
 
@@ -129,6 +129,7 @@ enum HighlightKind {
 pub struct HighlightTool {
     highlighter: Option<HighlightKind>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Drawable for HighlightKind {
@@ -145,6 +146,18 @@ impl Drawable for HighlightKind {
 }
 
 impl Tool for HighlightTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Highlight
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         let ctrl_pressed = event.modifier.intersects(ModifierType::CONTROL_MASK);

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -8,12 +8,13 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Default)]
 pub struct LineTool {
     line: Option<Line>,
     style: Style,
+    input_enabled: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -49,6 +50,14 @@ impl Drawable for Line {
 }
 
 impl Tool for LineTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {
@@ -117,5 +126,9 @@ impl Tool for LineTool {
             Some(d) => Some(d),
             None => None,
         }
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Line
     }
 }

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -8,11 +8,12 @@ use crate::sketch_board::{MouseButton, MouseEventType};
 use crate::style::Style;
 use crate::{math::Vec2D, sketch_board::MouseEventMsg};
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 pub struct MarkerTool {
     style: Style,
     next_number: Rc<RefCell<u16>>,
+    input_enabled: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -84,6 +85,18 @@ impl Drawable for Marker {
 }
 
 impl Tool for MarkerTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Marker
+    }
+
     fn get_drawable(&self) -> Option<&dyn Drawable> {
         None
     }
@@ -122,6 +135,7 @@ impl Default for MarkerTool {
         Self {
             style: Default::default(),
             next_number: Rc::new(RefCell::new(1)),
+            input_enabled: true
         }
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -91,6 +91,10 @@ pub trait Tool {
         false
     }
 
+    fn input_enabled(&self) -> bool;
+
+    fn set_input_enabled(&mut self, value: bool);
+
     fn handle_undo(&mut self) -> ToolUpdateResult {
         ToolUpdateResult::Unmodified
     }
@@ -100,6 +104,8 @@ pub trait Tool {
     }
 
     fn get_drawable(&self) -> Option<&dyn Drawable>;
+
+    fn get_tool_type(&self) -> Tools;
 }
 
 // the clone method below has been adapted from: https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -1,10 +1,24 @@
-use super::Tool;
+use super::{Tool, Tools};
 
 #[derive(Default)]
-pub struct PointerTool {}
+pub struct PointerTool {
+    input_enabled: bool,
+}
 
 impl Tool for PointerTool {
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Pointer
+    }
+
     fn get_drawable(&self) -> Option<&dyn super::Drawable> {
         None
+    }
+
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
     }
 }

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -9,7 +9,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Rectangle {
@@ -54,9 +54,18 @@ impl Drawable for Rectangle {
 pub struct RectangleTool {
     rectangle: Option<Rectangle>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for RectangleTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         match event.type_ {
@@ -138,5 +147,9 @@ impl Tool for RectangleTool {
             Some(d) => Some(d),
             None => None,
         }
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Rectangle
     }
 }

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -13,7 +13,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Debug)]
 pub struct Text {
@@ -155,9 +155,22 @@ impl Drawable for Text {
 pub struct TextTool {
     text: Option<Text>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for TextTool {
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Text
+    }
+
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn get_drawable(&self) -> Option<&dyn Drawable> {
         match &self.text {
             Some(d) => Some(d),
@@ -198,6 +211,7 @@ impl Tool for TextTool {
                     t.editing = false;
                     let result = t.clone_box();
                     self.text = None;
+                    self.input_enabled = false;
                     return ToolUpdateResult::Commit(result);
                 }
             } else if event.key == Key::Escape {
@@ -290,8 +304,11 @@ impl Tool for TextTool {
                     // create a new Text
                     self.text = Some(Text::new(event.pos, self.style));
 
+                    self.set_input_enabled(true);
+
                     return_value
                 } else {
+                    self.set_input_enabled(false);
                     ToolUpdateResult::Unmodified
                 }
             }


### PR DESCRIPTION
Hi folks, this is my very first community PR ever, and I'm also doing this to learn Rust, so bear that in mind.

## Description
This PR introduces changes to allow tool selection via keyboard shorcuts and closes https://github.com/gabm/Satty/issues/50.

| Tool      | Shortcut |
|-----------|----------|
| Pointer   | P   |
| Crop      | `C`  or `1` |
| Brush     | `B` or  `2`  |
| Line      | `L` or `3`  |
| Arrow     | `A` or `4`   |
| Rectangle | `R` or `5`   |
| Ellipse   | `E` or `6`   |
| Text      | `T` or `7`   |
| Marker    | `M` or `8`    |
| Blur      | `U` or `9`    |
| Highlight | `H` or `0`    |