### PR TITLE
make annotation_size_factor configurable from UI

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -363,6 +363,12 @@ impl SketchBoard {
                     .borrow_mut()
                     .handle_event(ToolEvent::StyleChanged(self.style))
             }
+            ToolbarEvent::AnnotationSizeChanged(value) => {
+                self.style.annotation_size_factor = value;
+                self.active_tool
+                    .borrow_mut()
+                    .handle_event(ToolEvent::StyleChanged(self.style))
+            }
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -11,11 +11,12 @@ use relm4::gtk::gdk::RGBA;
 
 use crate::configuration::APP_CONFIG;
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct Style {
     pub color: Color,
     pub size: Size,
     pub fill: bool,
+    pub annotation_size_factor: f32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -32,6 +33,17 @@ pub enum Size {
     #[default]
     Medium = 1,
     Large = 2,
+}
+
+impl Default for Style {
+    fn default() -> Self {
+        Self {
+            color: Color::default(),
+            size: Size::default(),
+            fill: bool::default(),
+            annotation_size_factor: APP_CONFIG.read().annotation_size_factor(),
+        }
+    }
 }
 
 impl Default for Color {
@@ -153,9 +165,9 @@ impl From<Style> for Paint {
     fn from(value: Style) -> Self {
         Paint::default()
             .with_anti_alias(true)
-            .with_font_size(value.size.to_text_size() as f32)
+            .with_font_size(value.size.to_text_size(value.annotation_size_factor) as f32)
             .with_color(value.color.into())
-            .with_line_width(value.size.to_line_width())
+            .with_line_width(value.size.to_line_width(value.annotation_size_factor))
     }
 }
 
@@ -183,9 +195,7 @@ impl FromVariant for Size {
 }
 
 impl Size {
-    pub fn to_text_size(self) -> i32 {
-        let size_factor = APP_CONFIG.read().annotation_size_factor();
-
+    pub fn to_text_size(self, size_factor: f32) -> i32 {
         match self {
             Size::Small => (36.0 * size_factor) as i32,
             Size::Medium => (54.0 * size_factor) as i32,
@@ -193,9 +203,7 @@ impl Size {
         }
     }
 
-    pub fn to_line_width(self) -> f32 {
-        let size_factor = APP_CONFIG.read().annotation_size_factor();
-
+    pub fn to_line_width(self, size_factor: f32) -> f32 {
         match self {
             Size::Small => 3.0 * size_factor,
             Size::Medium => 5.0 * size_factor,
@@ -203,8 +211,7 @@ impl Size {
         }
     }
 
-    pub fn to_arrow_tail_width(self) -> f32 {
-        let size_factor = APP_CONFIG.read().annotation_size_factor();
+    pub fn to_arrow_tail_width(self, size_factor: f32) -> f32 {
         match self {
             Size::Small => 3.0 * size_factor,
             Size::Medium => 10.0 * size_factor,
@@ -212,8 +219,7 @@ impl Size {
         }
     }
 
-    pub fn to_arrow_head_length(self) -> f32 {
-        let size_factor = APP_CONFIG.read().annotation_size_factor();
+    pub fn to_arrow_head_length(self, size_factor: f32) -> f32 {
         match self {
             Size::Small => 15.0 * size_factor,
             Size::Medium => 30.0 * size_factor,
@@ -221,8 +227,7 @@ impl Size {
         }
     }
 
-    pub fn to_blur_factor(self) -> f32 {
-        let size_factor = APP_CONFIG.read().annotation_size_factor();
+    pub fn to_blur_factor(self, size_factor: f32) -> f32 {
         match self {
             Size::Small => 10.0 * size_factor,
             Size::Medium => 20.0 * size_factor,
@@ -230,8 +235,7 @@ impl Size {
         }
     }
 
-    pub fn to_highlight_width(self) -> f32 {
-        let size_factor = APP_CONFIG.read().annotation_size_factor();
+    pub fn to_highlight_width(self, size_factor: f32) -> f32 {
         match self {
             Size::Small => 15.0 * size_factor,
             Size::Medium => 30.0 * size_factor,

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -152,9 +152,15 @@ impl Drawable for Arrow {
         canvas.rotate(arrow_direction.angle().radians);
 
         // The width of the tail (double distance from start to head side)
-        let tail_width = self.style.size.to_arrow_tail_width();
+        let tail_width = self
+            .style
+            .size
+            .to_arrow_tail_width(self.style.annotation_size_factor);
         // The length of the (sloped) side of the arrow head (distance from end to head side).
-        let head_side_length = self.style.size.to_arrow_head_length();
+        let head_side_length = self
+            .style
+            .size
+            .to_arrow_head_length(self.style.annotation_size_factor);
         // The offset of the midpoint is the distance the midpoint moves toward the end of the arrow.
         // A offset of 0 will place the midpoint right below the head side.
         // A negative value will result in a diamond head.

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -76,7 +76,8 @@ impl Drawable for Blur {
         };
         if self.editing {
             // set style
-            let paint = Paint::color(Color::black()).with_line_width(Size::Medium.to_line_width());
+            let paint = Paint::color(Color::black())
+                .with_line_width(Size::Medium.to_line_width(self.style.annotation_size_factor));
 
             // make rect
             let mut path = Path::new();
@@ -99,7 +100,9 @@ impl Drawable for Blur {
                     canvas,
                     pos,
                     size,
-                    self.style.size.to_blur_factor(),
+                    self.style
+                        .size
+                        .to_blur_factor(self.style.annotation_size_factor),
                 )?);
             }
 

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -79,7 +79,11 @@ impl Highlight for Highlighter<FreehandHighlight> {
             self.style.color.b,
             (255.0 * HIGHLIGHT_OPACITY) as u8,
         ));
-        paint.set_line_width(self.style.size.to_highlight_width());
+        paint.set_line_width(
+            self.style
+                .size
+                .to_highlight_width(self.style.annotation_size_factor),
+        );
         paint.set_line_join(femtovg::LineJoin::Round);
         paint.set_line_cap(femtovg::LineCap::Square);
 

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -33,7 +33,12 @@ impl Drawable for Marker {
 
         let mut paint = Paint::color(Color::white());
         paint.set_font(&[font]);
-        paint.set_font_size((self.style.size.to_text_size()) as f32);
+        paint.set_font_size(
+            (self
+                .style
+                .size
+                .to_text_size(self.style.annotation_size_factor)) as f32,
+        );
         paint.set_text_align(femtovg::Align::Center);
         paint.set_text_baseline(femtovg::Baseline::Middle);
 
@@ -63,8 +68,12 @@ impl Drawable for Marker {
             femtovg::Solidity::Solid,
         );
 
-        let circle_paint = Paint::color(self.style.color.into())
-            .with_line_width(self.style.size.to_line_width() * 2.0);
+        let circle_paint = Paint::color(self.style.color.into()).with_line_width(
+            self.style
+                .size
+                .to_line_width(self.style.annotation_size_factor)
+                * 2.0,
+        );
 
         canvas.save();
         canvas.fill_path(&inner_circle_path, &circle_paint);

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -26,6 +26,12 @@ pub struct StyleToolbar {
     custom_color_pixbuf: Pixbuf,
     color_action: SimpleAction,
     visible: bool,
+    annotation_size: f32,
+    annotation_dialog_controller: Option<Controller<AnnotationSizeDialog>>,
+}
+
+pub struct AnnotationSizeDialog {
+    annotation_size: f32,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -38,6 +44,7 @@ pub enum ToolbarEvent {
     SaveFile,
     CopyClipboard,
     ToggleFill,
+    AnnotationSizeChanged(f32),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -51,6 +58,21 @@ pub enum StyleToolbarInput {
     ShowColorDialog,
     ColorDialogFinished(Option<Color>),
     ToggleVisibility,
+    ShowAnnotationDialog,
+    AnnotationDialogFinished(Option<f32>),
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum AnnotationSizeDialogInput {
+    ValueChanged,
+    Reset,
+    Submit,
+    Cancel,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum AnnotationSizeDialogOutput {
+    AnnotationSizeSubmitted(f32),
 }
 
 fn create_icon_pixbuf(color: Color) -> Pixbuf {
@@ -309,6 +331,29 @@ impl StyleToolbar {
             ColorButtons::Custom => self.custom_color,
         }
     }
+
+    fn show_annotation_dialog(
+        &mut self,
+        sender: ComponentSender<StyleToolbar>,
+        root: Option<Window>,
+    ) {
+        let mut builder = AnnotationSizeDialog::builder();
+        if let Some(w) = root {
+            builder = builder.transient_for(&w);
+        }
+
+        let connector = builder.launch(self.annotation_size);
+
+        let controller = connector.forward(sender.input_sender(), |output| match output {
+            AnnotationSizeDialogOutput::AnnotationSizeSubmitted(value) => {
+                StyleToolbarInput::AnnotationDialogFinished(Some(value))
+            }
+        });
+        controller.widget().present();
+
+        // this is needed so the controller doesn't get dropped, causing panic
+        self.annotation_dialog_controller = Some(controller);
+    }
 }
 
 #[relm4::component(pub)]
@@ -376,6 +421,24 @@ impl Component for StyleToolbar {
                 set_tooltip: "Large size",
                 ActionablePlus::set_action::<SizeAction>: Size::Large,
             },
+            gtk::Label {
+                set_focusable: false,
+                set_hexpand: false,
+
+                set_text: "x",
+            },
+            #[name = "spin_revealer"]
+            gtk::Button {
+                set_focusable: false,
+                set_hexpand: false,
+
+                // TODO: this doesn't format properly, e.g. in de_DE
+                set_label: &format!("{:.2}", model.annotation_size),
+                set_tooltip: "Edit Annotation Size Factor",
+
+                connect_clicked => StyleToolbarInput::ShowAnnotationDialog
+            },
+            gtk::Separator {},
             gtk::Button {
                 set_focusable: false,
                 set_hexpand: false,
@@ -395,7 +458,13 @@ impl Component for StyleToolbar {
         },
     }
 
-    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>, root: &Self::Root) {
+    fn update_with_view(
+        &mut self,
+        widgets: &mut Self::Widgets,
+        message: Self::Input,
+        sender: ComponentSender<Self>,
+        root: &Self::Root,
+    ) {
         match message {
             StyleToolbarInput::ShowColorDialog => {
                 self.show_color_dialog(sender, root.toplevel_window());
@@ -422,11 +491,28 @@ impl Component for StyleToolbar {
                     .emit(ToolbarEvent::ColorSelected(color));
             }
 
+            StyleToolbarInput::ShowAnnotationDialog => {
+                self.show_annotation_dialog(sender, root.toplevel_window());
+            }
+
+            StyleToolbarInput::AnnotationDialogFinished(value) => {
+                if let Some(value) = value {
+                    // TODO: format error, see above
+                    widgets.spin_revealer.set_label(&format!("{0:.2}", value));
+                    self.annotation_size = value;
+
+                    sender
+                        .output_sender()
+                        .emit(ToolbarEvent::AnnotationSizeChanged(value));
+                }
+            }
+
             StyleToolbarInput::ToggleVisibility => {
                 self.visible = !self.visible;
             }
         }
     }
+
     fn init(
         _: Self::Init,
         root: Self::Root,
@@ -485,6 +571,8 @@ impl Component for StyleToolbar {
             custom_color_pixbuf,
             color_action: SimpleAction::from(color_action.clone()),
             visible: !APP_CONFIG.read().default_hide_toolbars(),
+            annotation_size: APP_CONFIG.read().annotation_size_factor(),
+            annotation_dialog_controller: None,
         };
 
         // create widgets
@@ -540,5 +628,148 @@ impl FromVariant for ColorButtons {
             std::u64::MAX => Self::Custom,
             _ => Self::Palette(v),
         })
+    }
+}
+
+#[relm4::component(pub)]
+impl Component for AnnotationSizeDialog {
+    type Init = f32;
+    type Input = AnnotationSizeDialogInput;
+    type Output = AnnotationSizeDialogOutput;
+    type CommandOutput = ();
+
+    view! {
+        gtk::Window {
+            set_modal: true,
+            set_title: Some("Choose Annotation Size"),
+            set_titlebar: Some(&header_bar),
+
+            #[wrap(Some)]
+            set_child = &gtk::Box {
+                set_spacing: 10,
+                set_margin_all: 12,
+                set_orientation: gtk::Orientation::Horizontal,
+
+                #[name = "spin"]
+                gtk::SpinButton {
+                    set_editable: true,
+                    set_can_focus: true,
+                    set_hexpand: false,
+
+                    set_tooltip: "Annotation Size Factor",
+                    set_numeric: true,
+                    set_adjustment: &gtk::Adjustment::new(model.annotation_size.into(), 0.0, 100.0, 0.01, 0.1, 0.0),
+                    set_climb_rate: 0.1,
+                    set_digits: 2,
+
+                    connect_value_changed[sender] => move |_| {
+                        sender.input(AnnotationSizeDialogInput::ValueChanged);
+                    },
+                },
+                #[name = "spin_reset"]
+                gtk::Button {
+                    set_focusable: false,
+                    set_hexpand: false,
+
+                    set_tooltip: "Reset Annotation Size Factor",
+                    set_icon_name: "edit-reset-symbolic",
+                    connect_clicked[sender] => move |_| {
+                        sender.input(AnnotationSizeDialogInput::Reset);
+                    },
+                },
+
+            },
+        }
+    }
+
+    fn init(
+        init_value: f32,
+        root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = AnnotationSizeDialog {
+            annotation_size: init_value,
+        };
+
+        // the title bar didn't really work within the view! macro.
+        let title_label = gtk::Label::builder()
+            .label("Choose Annotation Size")
+            .margin_start(6)
+            .build();
+
+        let cancel_button = gtk::Button::builder().label("Cancel").build();
+        let sender_clone = sender.clone();
+        cancel_button.connect_clicked(move |_| {
+            sender_clone.input(AnnotationSizeDialogInput::Cancel);
+        });
+
+        let ok_button = gtk::Button::builder().label("OK").build();
+
+        let sender_clone = sender.clone();
+        ok_button.connect_clicked(move |_| {
+            sender_clone.input(AnnotationSizeDialogInput::Submit);
+        });
+
+        let header_bar = gtk::HeaderBar::builder().show_title_buttons(false).build();
+
+        header_bar.set_title_widget(Some(&title_label));
+        header_bar.pack_start(&cancel_button);
+        header_bar.pack_end(&ok_button);
+
+        let widgets = view_output!();
+
+        let key_controller = gtk::EventControllerKey::builder()
+            // not sure if this is the correct phase, but anything higher and Enter to close doesn't work consistently
+            .propagation_phase(gtk::PropagationPhase::Capture)
+            .build();
+
+        key_controller.connect_key_pressed(move |_, keyval, _, _| {
+            use gtk::gdk::Key;
+            match keyval {
+                Key::Return => {
+                    sender.input(AnnotationSizeDialogInput::Submit);
+                    glib::Propagation::Stop
+                }
+                Key::Escape => {
+                    sender.input(AnnotationSizeDialogInput::Cancel);
+                    glib::Propagation::Stop
+                }
+                _ => glib::Propagation::Proceed,
+            }
+        });
+        root.add_controller(key_controller);
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update_with_view(
+        &mut self,
+        widgets: &mut Self::Widgets,
+        message: AnnotationSizeDialogInput,
+        sender: ComponentSender<Self>,
+        root: &Self::Root,
+    ) {
+        match message {
+            AnnotationSizeDialogInput::ValueChanged => {
+                self.annotation_size = widgets.spin.value() as f32
+            }
+            AnnotationSizeDialogInput::Reset => {
+                let a = APP_CONFIG.read().annotation_size_factor();
+                widgets.spin.set_value(a.into());
+                self.annotation_size = a;
+            }
+            AnnotationSizeDialogInput::Cancel => {
+                root.close();
+            }
+            AnnotationSizeDialogInput::Submit => {
+                // yeah, not sure if this can even happen.
+                if let Err(e) = sender.output(AnnotationSizeDialogOutput::AnnotationSizeSubmitted(
+                    widgets.spin.value() as f32,
+                )) {
+                    eprintln!("Error submitting annotation size factor: {:?}", e);
+                }
+                root.close();
+            }
+        }
     }
 }


### PR DESCRIPTION
Related to #106 

![satty-20250406-090844](https://github.com/user-attachments/assets/0fff0de4-e48d-4614-b526-4da0956db13e)
(screenshot outdated, see https://github.com/gabm/Satty/pull/154#issuecomment-2798812396)

- adds UI element to adjust `annotation_size_factor` config setting, using GTK SpinButton control. This affects the sizes of all tools and allows for finer control of the annotation sizes ;)
  - the SpinButton control offers by GTK default
    - left click to increase/decrease
    - right click to go to min/max
    - middle click to increase/decrease by a bigger jump
- adds reset  button allowing to going back to the default/configured value

The original goal of the issue was to make the font/font size configurable. I think somebody can implement that later, for now this seemed like a much quicker win.

TODO Items:
-  [x] make reset button more visible, not sure yet what the issue is, according to `GTK_DEBUG=interactive` it has the same color as the others. Edit: it was "edit-reset" vs "edit-reset-symbolic"
- [x] consider GTK drawer for the additional UI elements
- [x] allow focus of the text input box. i disabled this for now as it stole focus from the text annotation tool - no longer a concern because the control has been moved into a dialog

Also, I'm not really familiar with Relm. I couldn't say if all of this is the best possible way to implement it. It does work here and didn't seem to break anything. ;) I have tried adjusting the `APP_CONFIG` with `write` but that led to deadlocks (or `WouldBlock` with `try_write`) -- since nothing else writes except for intially command line parameters and config, this might not have been the way to go anyway.