### PR TITLE
feat: add option to allow copy to clipboard by right click

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
 action-on-enter = "save-to-clipboard"
 # After copying the screenshot, save it to a file as well
 save-after-copy = false
+# Right click to copy
+right-click-copy = false
 # Hide toolbars by default
 default-hide-toolbars = false
 # The primary highlighter to use, the other is accessible by holding CTRL at the start of a highlight [possible values: block, freehand]
@@ -145,6 +147,8 @@ Options:
           Action to perform when pressing Enter [possible values: save-to-clipboard, save-to-file]
       --save-after-copy
           After copying the screenshot, save it to a file as well
+      --right-click-copy
+          Right click to copy
   -d, --default-hide-toolbars
           Hide toolbars by default
       --primary-highlighter <PRIMARY_HIGHLIGHTER>

--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,8 @@ output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
 action-on-enter = "save-to-clipboard"
 # After copying the screenshot, save it to a file as well
 save-after-copy = false
+# Right click to copy
+right-click-copy = false
 # Hide toolbars by default
 default-hide-toolbars = false
 # The primary highlighter to use, the other is accessible by holding CTRL at the start of a highlight [possible values: block, freehand]

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -49,6 +49,10 @@ pub struct CommandLine {
     #[arg(long)]
     pub save_after_copy: bool,
 
+    /// Right click to copy
+    #[arg(long)]
+    pub right_click_copy: bool,
+
     /// Hide toolbars by default
     #[arg(short, long)]
     pub default_hide_toolbars: bool,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -42,6 +42,7 @@ pub struct Configuration {
     annotation_size_factor: f32,
     action_on_enter: Action,
     save_after_copy: bool,
+    right_click_copy: bool,
     color_palette: ColorPalette,
     default_hide_toolbars: bool,
     font: FontConfiguration,
@@ -165,6 +166,9 @@ impl Configuration {
         if let Some(v) = general.save_after_copy {
             self.save_after_copy = v;
         }
+        if let Some(v) = general.right_click_copy {
+            self.right_click_copy = v;
+        }
         if let Some(v) = general.default_hide_toolbars {
             self.default_hide_toolbars = v;
         }
@@ -223,6 +227,9 @@ impl Configuration {
         if command_line.save_after_copy {
             self.save_after_copy = command_line.save_after_copy;
         }
+        if command_line.right_click_copy {
+            self.right_click_copy = command_line.right_click_copy;
+        }
         if let Some(v) = command_line.font_family {
             self.font.family = Some(v);
         }
@@ -278,6 +285,10 @@ impl Configuration {
         self.save_after_copy
     }
 
+    pub fn right_click_copy(&self) -> bool {
+        self.right_click_copy
+    }
+
     pub fn color_palette(&self) -> &ColorPalette {
         &self.color_palette
     }
@@ -310,6 +321,7 @@ impl Default for Configuration {
             annotation_size_factor: 1.0,
             action_on_enter: Action::SaveToClipboard,
             save_after_copy: false,
+            right_click_copy: false,
             color_palette: ColorPalette::default(),
             default_hide_toolbars: false,
             font: FontConfiguration::default(),
@@ -361,6 +373,7 @@ struct ConfigurationFileGeneral {
     output_filename: Option<String>,
     action_on_enter: Option<Action>,
     save_after_copy: Option<bool>,
+    right_click_copy: Option<bool>,
     default_hide_toolbars: Option<bool>,
     primary_highlighter: Option<Highlighters>,
     disable_notifications: Option<bool>,

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -122,17 +122,36 @@ impl From<u32> for MouseButton {
 }
 
 impl InputEvent {
-    fn remap_event_coordinates(&mut self, renderer: &FemtoVGArea) {
+    fn handle_event_mouse_input(
+        &mut self,
+        renderer: &FemtoVGArea,
+        sender: &ComponentSender<SketchBoard>,
+    ) -> Option<ToolUpdateResult> {
         if let InputEvent::Mouse(me) = self {
             match me.type_ {
-                MouseEventType::BeginDrag | MouseEventType::Click => {
-                    me.pos = renderer.abs_canvas_to_image_coordinates(me.pos)
+                MouseEventType::Click => {
+                    if me.button == MouseButton::Secondary && APP_CONFIG.read().right_click_copy() {
+                        sender
+                            .input_sender()
+                            .send(SketchBoardInput::ToolbarEvent(ToolbarEvent::CopyClipboard))
+                            .unwrap();
+                        None
+                    } else {
+                        None
+                    }
+                }
+                MouseEventType::BeginDrag => {
+                    me.pos = renderer.abs_canvas_to_image_coordinates(me.pos);
+                    None
                 }
                 MouseEventType::EndDrag | MouseEventType::UpdateDrag => {
-                    me.pos = renderer.rel_canvas_to_image_coordinates(me.pos)
+                    me.pos = renderer.rel_canvas_to_image_coordinates(me.pos);
+                    None
                 }
             }
-        };
+        } else {
+            None
+        }
     }
 }
 
@@ -471,7 +490,7 @@ impl Component for SketchBoard {
                             .handle_event(ToolEvent::Input(ie))
                     }
                 } else {
-                    ie.remap_event_coordinates(&self.renderer);
+                    ie.handle_event_mouse_input(&self.renderer, &sender);
                     self.active_tool
                         .borrow_mut()
                         .handle_event(ToolEvent::Input(ie))


### PR DESCRIPTION
After editing the picture with the mouse, if you can directly use the right-click button to copy, it will greatly increase the copying speed, because there is no need to carefully position the mouse on the copy button, nor is there a need to touch the keyboard separately
