### PR TITLE
Issue #91: intercept chrono panic

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -193,7 +193,7 @@ impl SketchBoard {
     }
 
     fn handle_save(&self, image: Pixbuf) {
-        let output_filename = match APP_CONFIG.read().output_filename() {
+        let mut output_filename = match APP_CONFIG.read().output_filename() {
             None => {
                 println!("No Output filename specified!");
                 return;
@@ -209,13 +209,12 @@ impl SketchBoard {
 
         if result.is_err() {
             println!(
-                "Filename {} caused a chrono format error, cannot save file.",
+                "Warning: Could not format filename {} due to chrono format error, falling back to literal filename.",
                 output_filename
             );
-            return;
+        } else {
+            output_filename = format!("{}", delayed_format);
         }
-
-        let output_filename = format!("{}", delayed_format);
 
         // TODO: we could support more data types
         if !output_filename.ends_with(".png") {

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -8,6 +8,7 @@ use keycode::{KeyMap, KeyMappingId};
 use std::cell::RefCell;
 use std::fs;
 use std::io::Write;
+use std::panic;
 use std::process::{Command, Stdio};
 use std::rc::Rc;
 
@@ -201,7 +202,20 @@ impl SketchBoard {
         };
 
         // run the output filename by "chrono date format"
-        let output_filename = format!("{}", chrono::Local::now().format(&output_filename));
+        let delayed_format = chrono::Local::now().format(&output_filename);
+        let result = panic::catch_unwind(|| {
+            delayed_format.to_string();
+        });
+
+        if result.is_err() {
+            println!(
+                "Filename {} caused a chrono format error, cannot save file.",
+                output_filename
+            );
+            return;
+        }
+
+        let output_filename = format!("{}", delayed_format);
 
         // TODO: we could support more data types
         if !output_filename.ends_with(".png") {


### PR DESCRIPTION
When DelayedFormat is used, and the format string cannot be processed (e.g. invalid), this causes a panic.

See related discussion in
https://github.com/chronotope/chrono/issues/1588

Use fallible function in the future once available, for now: catch_unwind the panic. 

I'm not auto closing the issue #91 from here, we might still need that for tracking purposes for future changes here.