### PR TITLE
fix: miss update coordinates in mouse  click event

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -137,6 +137,7 @@ impl InputEvent {
                             .unwrap();
                         None
                     } else {
+                        me.pos = renderer.abs_canvas_to_image_coordinates(me.pos);
                         None
                     }
                 }


### PR DESCRIPTION
fix the bug from the pr:
https://github.com/gabm/Satty/pull/155