### PR TITLE
add --profile-startup

### DIFF
--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -72,6 +72,10 @@ pub struct CommandLine {
     /// Disable notifications
     #[arg(long)]
     pub disable_notifications: bool,
+
+    /// print profiling
+    #[arg(long)]
+    pub profile_startup: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -48,6 +48,7 @@ pub struct Configuration {
     font: FontConfiguration,
     primary_highlighter: Highlighters,
     disable_notifications: bool,
+    profile_startup: bool,
 }
 
 #[derive(Default)]
@@ -243,6 +244,9 @@ impl Configuration {
         if command_line.disable_notifications {
             self.disable_notifications = command_line.disable_notifications;
         }
+        if command_line.profile_startup {
+            self.profile_startup = command_line.profile_startup;
+        }
     }
 
     pub fn early_exit(&self) -> bool {
@@ -303,6 +307,11 @@ impl Configuration {
     pub fn disable_notifications(&self) -> bool {
         self.disable_notifications
     }
+
+    pub fn profile_startup(&self) -> bool {
+        self.profile_startup
+    }
+
     pub fn font(&self) -> &FontConfiguration {
         &self.font
     }
@@ -327,6 +336,7 @@ impl Default for Configuration {
             font: FontConfiguration::default(),
             primary_highlighter: Highlighters::Block,
             disable_notifications: false,
+            profile_startup: false,
         }
     }
 }


### PR DESCRIPTION
Parameter only but no config option (for now). This prints profiling for app startup, e.g.

```
startup timestamp was 1746683407.715279841 2025-50-08 07:50:07
    1 ms time elapsed: "configuration loaded"
    1 ms time elapsed: "loaded gl"
    1 ms time elapsed: "loading image"
  412 ms time elapsed: "image loaded, starting gui"
  474 ms time elapsed: "app init end"
  540 ms time elapsed: "gui show event"
  543 ms time elapsed: "main loop idle"
```

Useful to combine with LD_DEBUG, e.g.
`date "+%s,%N" && LD_DEBUG=statistics  satty --filename ~/Downloads/big_noise.png --profile-startup`
