### PR TITLE
feature: escape action

### DIFF
--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -45,6 +45,10 @@ pub struct CommandLine {
     #[arg(long)]
     pub action_on_enter: Option<Action>,
 
+    /// Action to perform when pressing Escape
+    #[arg(long)]
+    pub action_on_escape: Option<Action>,
+
     /// After copying the screenshot, save it to a file as well
     #[arg(long)]
     pub save_after_copy: bool,
@@ -94,11 +98,13 @@ pub enum Tools {
     Brush,
 }
 
-#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum Action {
-    #[default]
     SaveToClipboard,
     SaveToFile,
+    SaveToClipboardAndExit,
+    SaveToFileAndExit,
+    Exit,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -41,6 +41,7 @@ pub struct Configuration {
     copy_command: Option<String>,
     annotation_size_factor: f32,
     action_on_enter: Action,
+    action_on_escape: Action,
     save_after_copy: bool,
     right_click_copy: bool,
     color_palette: ColorPalette,
@@ -103,6 +104,9 @@ impl ColorPalette {
 pub enum Action {
     SaveToClipboard,
     SaveToFile,
+    Exit,
+    SaveToClipboardAndExit,
+    SaveToFileAndExit,
 }
 
 impl From<CommandLineAction> for Action {
@@ -110,6 +114,9 @@ impl From<CommandLineAction> for Action {
         match action {
             CommandLineAction::SaveToClipboard => Self::SaveToClipboard,
             CommandLineAction::SaveToFile => Self::SaveToFile,
+            CommandLineAction::Exit => Self::Exit,
+            CommandLineAction::SaveToClipboardAndExit => Self::SaveToClipboardAndExit,
+            CommandLineAction::SaveToFileAndExit => Self::SaveToFileAndExit,
         }
     }
 }
@@ -167,6 +174,9 @@ impl Configuration {
         }
         if let Some(v) = general.action_on_enter {
             self.action_on_enter = v;
+        }
+        if let Some(v) = general.action_on_escape {
+            self.action_on_escape = v;
         }
         if let Some(v) = general.save_after_copy {
             self.save_after_copy = v;
@@ -229,6 +239,9 @@ impl Configuration {
         if let Some(v) = command_line.action_on_enter {
             self.action_on_enter = v.into();
         }
+        if let Some(v) = command_line.action_on_escape {
+            self.action_on_escape = v.into();
+        }
         if command_line.save_after_copy {
             self.save_after_copy = command_line.save_after_copy;
         }
@@ -289,6 +302,10 @@ impl Configuration {
         self.action_on_enter
     }
 
+    pub fn action_on_escape(&self) -> Action {
+        self.action_on_escape
+    }
+
     pub fn save_after_copy(&self) -> bool {
         self.save_after_copy
     }
@@ -333,6 +350,7 @@ impl Default for Configuration {
             copy_command: None,
             annotation_size_factor: 1.0,
             action_on_enter: Action::SaveToClipboard,
+            action_on_escape: Action::Exit,
             save_after_copy: false,
             right_click_copy: false,
             color_palette: ColorPalette::default(),
@@ -386,6 +404,7 @@ struct ConfigurationFileGeneral {
     annotation_size_factor: Option<f32>,
     output_filename: Option<String>,
     action_on_enter: Option<Action>,
+    action_on_escape: Option<Action>,
     save_after_copy: Option<bool>,
     right_click_copy: Option<bool>,
     default_hide_toolbars: Option<bool>,


### PR DESCRIPTION
fixes #172

### How

I've reused the action on enter idea.
I've made 3 new actions but we could argue that `early_exit` is enough.

### Example

```
➜  void-packages git:(satty) ✗ grim -t png -g "$(slurp -d)" - | satty -f - --action-on-escape=save-to-clipboard-and-exit --copy-command=wl-copy
config file not found
Copied to clipboard.
➜  void-packages git:(satty) ✗ 
```

![image](https://github.com/user-attachments/assets/250ce28b-5440-4a12-b5db-f69f0a54a4b5)

### Misc

My first attempt was roughly this but it was unconsistent:
```rust
    // /!\ not consistent
    pub fn request_render_then(&self, action: Action, callback: impl FnOnce() + 'static) {
        let handler_id_rc: Rc<RefCell<Option<glib::SignalHandlerId>>> = Rc::new(RefCell::new(None));
        let callback_rc: CallbackBox = Rc::new(RefCell::new(Some(Box::new(callback))));
    
        let obj = self.obj();
        let handler_id_clone = handler_id_rc.clone();
    
        let handler_id = obj.connect_render(move |gl_area, _| {
            // call the callback
            if let Some(callback) = callback_rc.borrow_mut().take() {
                callback();
            }
            // disconnect handler
            if let Some(id) = handler_id_clone.borrow_mut().take() {
                gl_area.disconnect(id);
            }
            glib::Propagation::Proceed
        });
    
        handler_id_rc.borrow_mut().replace(handler_id);
        self.request_render.borrow_mut().replace(action);
        obj.queue_render();
    }
```
