### PR TITLE
triggers - actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,17 +86,31 @@ copy-command = "wl-copy"
 annotation-size-factor = 2
 # Filename to use for saving action. Omit to disable saving to file. Might contain format specifiers: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
 output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
-# Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
-action-on-enter = "save-to-clipboard"
+
 # After copying the screenshot, save it to a file as well
 save-after-copy = false
-# Right click to copy
-right-click-copy = false
 # Hide toolbars by default
 default-hide-toolbars = false
 # The primary highlighter to use, the other is accessible by holding CTRL at the start of a highlight [possible values: block, freehand]
 primary-highlighter = "block"
+# Disable notifications
 disable-notifications = false
+# Actions to trigger on right click (order is important)
+# [possible values: save-to-clipboard, save-to-file, exit]
+actions-on-right-click = []
+# Actions to trigger on Enter key (order is important)
+# [possible values: save-to-clipboard, save-to-file, exit]
+actions-on-enter = ["save-to-clipboard"]
+# Actions to trigger on Escape key (order is important)
+# [possible values: save-to-clipboard, save-to-file, exit]
+actions-on-escape = ["exit"]
+
+# Action to perform when the Enter key is pressed [possible values: save-to-clipboard, save-to-file]
+# Deprecated: use actions-on-enter instead
+action-on-enter = "save-to-clipboard"
+# Right click to copy
+# Deprecated: use actions-on-right-click instead
+right-click-copy = false
 
 # Font to use for text annotations
 [font]
@@ -143,33 +157,43 @@ Options:
       --fullscreen
           Start Satty in fullscreen mode
   -o, --output-filename <OUTPUT_FILENAME>
-          Filename to use for saving action. Omit to disable saving to file. Might contain format specifiers: <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>
+          Filename to use for saving action or '-' to print to stdout. Omit to disable saving to file. Might contain format specifiers: <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>
       --early-exit
           Exit directly after copy/save action
-      --corner-roundness <ROUNDNESS_FACTOR>
-          Draw corners of rectangles round if the value is greater than 0 (0 disables rounded corners)
+      --corner-roundness <CORNER_ROUNDNESS>
+          Draw corners of rectangles round if the value is greater than 0 (Defaults to 12) (0 disables rounded corners)
       --initial-tool <TOOL>
-          Select the tool on startup [aliases: init-tool] [possible values: pointer, crop, line, arrow, rectangle, text, marker, blur, brush]
+          Select the tool on startup [aliases: init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, highlight, brush]
       --copy-command <COPY_COMMAND>
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
           Increase or decrease the size of the annotations
-      --action-on-enter <ACTION_ON_ENTER>
-          Action to perform when pressing Enter [possible values: save-to-clipboard, save-to-file]
       --save-after-copy
-          After copying the screenshot, save it to a file as well
-      --right-click-copy
-          Right click to copy
+          After copying the screenshot, save it to a file as well Preferably use the `action_on_copy` option instead
+      --actions-on-enter <ACTIONS_ON_ENTER>
+          Actions to perform when pressing Enter [possible values: save-to-clipboard, save-to-file, exit]
+      --actions-on-escape <ACTIONS_ON_ESCAPE>
+          Actions to perform when pressing Escape [possible values: save-to-clipboard, save-to-file, exit]
+      --actions-on-right-click <ACTIONS_ON_RIGHT_CLICK>
+          Actions to perform when hitting the copy Button [possible values: save-to-clipboard, save-to-file, exit]
   -d, --default-hide-toolbars
           Hide toolbars by default
-      --primary-highlighter <PRIMARY_HIGHLIGHTER>
-          The primary highlighter to use, secondary is accessible with CTRL [possible values: block, freehand]
-      --disable-notifications
-          Disable notifications
       --font-family <FONT_FAMILY>
           Font family to use for text annotations
       --font-style <FONT_STYLE>
           Font style to use for text annotations
+      --primary-highlighter <PRIMARY_HIGHLIGHTER>
+          The primary highlighter to use, secondary is accessible with CTRL [possible values: block, freehand]
+      --disable-notifications
+          Disable notifications
+      --profile-startup
+          Print profiling
+      --no-window-decoration
+          Disable the window decoration (title bar, borders, etc.)
+      --right-click-copy
+          Right click to copy. Preferably use the `action_on_right_click` option instead
+      --action-on-enter <ACTION_ON_ENTER>
+          Action to perform when pressing Enter. Preferably use the `actions_on_enter` option instead [possible values: save-to-clipboard, save-to-file, exit]
   -h, --help
           Print help
   -V, --version

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -41,21 +41,22 @@ pub struct CommandLine {
     #[arg(long)]
     pub annotation_size_factor: Option<f32>,
 
-    /// Action to perform when pressing Enter
-    #[arg(long)]
-    pub action_on_enter: Option<Action>,
-
-    /// Action to perform when pressing Escape
-    #[arg(long)]
-    pub action_on_escape: Option<Action>,
-
     /// After copying the screenshot, save it to a file as well
+    /// Preferably use the `action_on_copy` option instead.
     #[arg(long)]
     pub save_after_copy: bool,
 
-    /// Right click to copy
-    #[arg(long)]
-    pub right_click_copy: bool,
+    /// Actions to perform when pressing Enter
+    #[arg(long, value_delimiter = ',')]
+    pub actions_on_enter: Option<Vec<Action>>,
+
+    /// Actions to perform when pressing Escape
+    #[arg(long, value_delimiter = ',')]
+    pub actions_on_escape: Option<Vec<Action>>,
+
+    /// Actions to perform when hitting the copy Button.
+    #[arg(long, value_delimiter = ',')]
+    pub actions_on_right_click: Option<Vec<Action>>,
 
     /// Hide toolbars by default
     #[arg(short, long)]
@@ -90,6 +91,17 @@ pub struct CommandLine {
     /// The default value is 0 (disabled).
     #[arg(long)]
     pub brush_smooth_history_size: Option<usize>,
+
+    // --- deprecated options ---
+    /// Right click to copy.
+    /// Preferably use the `action_on_right_click` option instead.
+    #[arg(long)]
+    pub right_click_copy: bool,
+    /// Action to perform when pressing Enter.
+    /// Preferably use the `actions_on_enter` option instead.
+    #[arg(long, value_delimiter = ',')]
+    pub action_on_enter: Option<Action>,
+    // ---
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -112,8 +124,6 @@ pub enum Tools {
 pub enum Action {
     SaveToClipboard,
     SaveToFile,
-    SaveToClipboardAndExit,
-    SaveToFileAndExit,
     Exit,
 }
 

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -31,7 +31,7 @@ pub struct FemtoVGArea {
     canvas: RefCell<Option<femtovg::Canvas<femtovg::renderer::OpenGl>>>,
     font: RefCell<Option<FontId>>,
     inner: RefCell<Option<FemtoVgAreaMut>>,
-    request_render: RefCell<Option<Action>>,
+    request_render: RefCell<Option<Vec<Action>>>,
     sender: RefCell<Option<Sender<SketchBoardInput>>>,
 }
 
@@ -98,10 +98,10 @@ impl GLAreaImpl for FemtoVGArea {
         let mut bc = self.canvas.borrow_mut();
         let canvas = bc.as_mut().unwrap(); // this unwrap is safe as long as we call "ensure_canvas" before
         let font = self.font.borrow().unwrap(); // this unwrap is safe as long as we call "ensure_canvas" before
-        let mut action = self.request_render.borrow_mut();
+        let mut actions = self.request_render.borrow_mut();
 
         // if we got requested to render a frame
-        if let Some(a) = action.as_ref() {
+        if let Some(a) = actions.take() {
             // render image
             let image = match self
                 .inner()
@@ -121,10 +121,10 @@ impl GLAreaImpl for FemtoVGArea {
                 .borrow()
                 .as_ref()
                 .expect("Did you call init before using FemtoVgArea?")
-                .emit(SketchBoardInput::RenderResult(image, *a));
+                .emit(SketchBoardInput::RenderResult(image, a));
 
             // reset request
-            *action = None;
+            *actions = None;
         }
         if let Err(e) = self
             .inner()
@@ -227,8 +227,8 @@ impl FemtoVGArea {
     pub fn inner(&self) -> RefMut<'_, Option<FemtoVgAreaMut>> {
         self.inner.borrow_mut()
     }
-    pub fn request_render(&self, action: Action) {
-        self.request_render.borrow_mut().replace(action);
+    pub fn request_render(&self, actions: &[Action]) {
+        self.request_render.borrow_mut().replace(actions.into());
         self.obj().queue_render();
     }
     pub fn set_parent_sender(&self, sender: Sender<SketchBoardInput>) {

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -57,8 +57,8 @@ impl FemtoVGArea {
             .expect("Did you call init before using FemtoVgArea?")
             .redo()
     }
-    pub fn request_render(&self, action: Action) {
-        self.imp().request_render(action);
+    pub fn request_render(&self, actions: &[Action]) {
+        self.imp().request_render(actions);
     }
     pub fn reset(&mut self) -> bool {
         self.imp()


### PR DESCRIPTION
fixes #187 

## How to test
```
grim -t ppm -g "$(slurp -d)" - | cargo run  -- -f - 
--copy-command=wl-copy --action-on-escape=save-to-clipboard,exit
```

```
grim -t ppm -g "$(slurp -d)" - | cargo run  -- -f - 
--copy-command=wl-copy --action-on-escape=save-to-clipboard
```

## TODOs
- [x] Connect everything
- [x] Tests the other scenarii
- [x] Clippy
- [x] Doc (README.md)
  - [x] cli
  - [x] toml
- [x] Better clap --help
  - [x] Deprecated args
  - [x] Maybe add new args using plural forms, and deprecate the others?
