### PR TITLE
fix: text: undo all not working for active text tool

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -352,13 +352,20 @@ impl SketchBoard {
     }
 
     fn handle_reset(&mut self) -> ToolUpdateResult {
+        let mut rv = ToolUpdateResult::Unmodified;
         if self.active_tool.borrow().active() {
-            self.active_tool.borrow_mut().handle_undo()
-        } else if self.renderer.reset() {
-            ToolUpdateResult::Redraw
-        } else {
-            ToolUpdateResult::Unmodified
+            if let ToolUpdateResult::Commit(result) =
+                self.active_tool.borrow_mut().handle_deactivated()
+            {
+                self.renderer.commit(result);
+                rv = ToolUpdateResult::Redraw;
+            }
         }
+
+        if self.renderer.reset() {
+            rv = ToolUpdateResult::Redraw;
+        }
+        rv
     }
 
     // Toolbars = Tools Toolbar + Style Toolbar


### PR DESCRIPTION
Closes #193

If text tool is currently active:
- deactivate text tool so handle_reset doesn't get stuck with text tool's handle_undo
- commit the result so the active text is available for redo