### PR TITLE
feat: show/hide toolbars based on window focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ output-filename = "/tmp/test-%Y-%m-%d_%H:%M:%S.png"
 save-after-copy = false
 # Hide toolbars by default
 default-hide-toolbars = false
+# Experimental: whether window focus shows/hides toolbars. This does not affect initial state of toolbars, see default-hide-toolbars.
+focus-toggles-toolbars = false
 # The primary highlighter to use, the other is accessible by holding CTRL at the start of a highlight [possible values: block, freehand]
 primary-highlighter = "block"
 # Disable notifications
@@ -166,6 +168,8 @@ Options:
           Actions to perform when hitting the copy Button [possible values: save-to-clipboard, save-to-file, exit]
   -d, --default-hide-toolbars
           Hide toolbars by default
+      --focus-toggles-toolbars
+          Experimental: Whether to toggle toolbars based on focus. Doesn't affect initial state
       --font-family <FONT_FAMILY>
           Font family to use for text annotations
       --font-style <FONT_STYLE>

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -62,6 +62,10 @@ pub struct CommandLine {
     #[arg(short, long)]
     pub default_hide_toolbars: bool,
 
+    /// Experimental: Whether to toggle toolbars based on focus. Doesn't affect initial state.
+    #[arg(long)]
+    pub focus_toggles_toolbars: bool,
+
     /// Font family to use for text annotations
     #[arg(long)]
     pub font_family: Option<String>,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -46,6 +46,7 @@ pub struct Configuration {
     actions_on_right_click: Vec<Action>,
     color_palette: ColorPalette,
     default_hide_toolbars: bool,
+    focus_toggles_toolbars: bool,
     font: FontConfiguration,
     primary_highlighter: Highlighters,
     disable_notifications: bool,
@@ -185,6 +186,9 @@ impl Configuration {
         if let Some(v) = general.default_hide_toolbars {
             self.default_hide_toolbars = v;
         }
+        if let Some(v) = general.focus_toggles_toolbars {
+            self.focus_toggles_toolbars = v;
+        }
         if let Some(v) = general.primary_highlighter {
             self.primary_highlighter = v;
         }
@@ -242,6 +246,9 @@ impl Configuration {
         }
         if command_line.default_hide_toolbars {
             self.default_hide_toolbars = command_line.default_hide_toolbars;
+        }
+        if command_line.focus_toggles_toolbars {
+            self.focus_toggles_toolbars = command_line.focus_toggles_toolbars
         }
         if let Some(v) = command_line.initial_tool {
             self.initial_tool = v.into();
@@ -360,6 +367,10 @@ impl Configuration {
         self.default_hide_toolbars
     }
 
+    pub fn focus_toggles_toolbars(&self) -> bool {
+        self.focus_toggles_toolbars
+    }
+
     pub fn primary_highlighter(&self) -> Highlighters {
         self.primary_highlighter
     }
@@ -402,6 +413,7 @@ impl Default for Configuration {
             actions_on_right_click: vec![],
             color_palette: ColorPalette::default(),
             default_hide_toolbars: false,
+            focus_toggles_toolbars: false,
             font: FontConfiguration::default(),
             primary_highlighter: Highlighters::Block,
             disable_notifications: false,
@@ -457,6 +469,7 @@ struct ConfigurationFileGeneral {
     actions_on_escape: Option<Vec<Action>>,
     actions_on_right_click: Option<Vec<Action>>,
     default_hide_toolbars: Option<bool>,
+    focus_toggles_toolbars: Option<bool>,
     primary_highlighter: Option<Highlighters>,
     disable_notifications: Option<bool>,
     no_window_decoration: Option<bool>,

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -51,6 +51,7 @@ pub enum ToolbarEvent {
 
 #[derive(Debug, Copy, Clone)]
 pub enum ToolsToolbarInput {
+    SetVisibility(bool),
     ToggleVisibility,
 }
 
@@ -59,6 +60,7 @@ pub enum StyleToolbarInput {
     ColorButtonSelected(ColorButtons),
     ShowColorDialog,
     ColorDialogFinished(Option<Color>),
+    SetVisibility(bool),
     ToggleVisibility,
     ShowAnnotationDialog,
     AnnotationDialogFinished(Option<f32>),
@@ -245,6 +247,7 @@ impl SimpleComponent for ToolsToolbar {
 
     fn update(&mut self, message: Self::Input, _sender: ComponentSender<Self>) {
         match message {
+            ToolsToolbarInput::SetVisibility(visible) => self.visible = visible,
             ToolsToolbarInput::ToggleVisibility => {
                 self.visible = !self.visible;
             }
@@ -515,6 +518,7 @@ impl Component for StyleToolbar {
                 }
             }
 
+            StyleToolbarInput::SetVisibility(visible) => self.visible = visible,
             StyleToolbarInput::ToggleVisibility => {
                 self.visible = !self.visible;
             }


### PR DESCRIPTION
Addition for #42.

This does not affect the initial state of toolbars, only subsequent enter/leave events.

Further discussion might be needed in #42 whether default-hide-toolbars should have a tri-state (along the lines of "initial state of toolbars"), hide/show/focus-based.