### PR TITLE
option for filling shapes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ save-after-copy = false
 default-hide-toolbars = false
 # Experimental: whether window focus shows/hides toolbars. This does not affect initial state of toolbars, see default-hide-toolbars.
 focus-toggles-toolbars = false
+# Fill shapes by default
+default-fill-shapes = false
 # The primary highlighter to use, the other is accessible by holding CTRL at the start of a highlight [possible values: block, freehand]
 primary-highlighter = "block"
 # Disable notifications
@@ -153,7 +155,7 @@ Options:
       --corner-roundness <CORNER_ROUNDNESS>
           Draw corners of rectangles round if the value is greater than 0 (Defaults to 12) (0 disables rounded corners)
       --initial-tool <TOOL>
-          Select the tool on startup [aliases: init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, highlight, brush]
+          Select the tool on startup [aliases: --init-tool] [possible values: pointer, crop, line, arrow, rectangle, ellipse, text, marker, blur, highlight, brush]
       --copy-command <COPY_COMMAND>
           Configure the command to be called on copy, for example `wl-copy`
       --annotation-size-factor <ANNOTATION_SIZE_FACTOR>
@@ -170,6 +172,8 @@ Options:
           Hide toolbars by default
       --focus-toggles-toolbars
           Experimental: Whether to toggle toolbars based on focus. Doesn't affect initial state
+      --default-fill-shapes
+          Fill shapes by default
       --font-family <FONT_FAMILY>
           Font family to use for text annotations
       --font-style <FONT_STYLE>
@@ -182,14 +186,12 @@ Options:
           Print profiling
       --no-window-decoration
           Disable the window decoration (title bar, borders, etc.)
+      --brush-smooth-history-size <BRUSH_SMOOTH_HISTORY_SIZE>
+          How much points to use for the brush smoothing algorithm 0 disables smoothing. The default value is 0 (disabled)
       --right-click-copy
           Right click to copy. Preferably use the `action_on_right_click` option instead
       --action-on-enter <ACTION_ON_ENTER>
           Action to perform when pressing Enter. Preferably use the `actions_on_enter` option instead [possible values: save-to-clipboard, save-to-file, exit]
-      --no-window-decoration
-          Request no window decoration. Please note that the compositor has the final say in this. At this point. requires xdg-decoration-unstable-v1.
-      --brush-smooth-history-size <SIZE>
-          Experimental feature: Adjust history size for brush input smooting (0: disabled, default: 0, try e.g. 5 or 10)
   -h, --help
           Print help
   -V, --version

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -66,6 +66,10 @@ pub struct CommandLine {
     #[arg(long)]
     pub focus_toggles_toolbars: bool,
 
+    /// Fill shapes by default
+    #[arg(long)]
+    pub default_fill_shapes: bool,
+
     /// Font family to use for text annotations
     #[arg(long)]
     pub font_family: Option<String>,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -47,6 +47,7 @@ pub struct Configuration {
     color_palette: ColorPalette,
     default_hide_toolbars: bool,
     focus_toggles_toolbars: bool,
+    default_fill_shapes: bool,
     font: FontConfiguration,
     primary_highlighter: Highlighters,
     disable_notifications: bool,
@@ -189,6 +190,9 @@ impl Configuration {
         if let Some(v) = general.focus_toggles_toolbars {
             self.focus_toggles_toolbars = v;
         }
+        if let Some(v) = general.default_fill_shapes {
+            self.default_fill_shapes = v;
+        }
         if let Some(v) = general.primary_highlighter {
             self.primary_highlighter = v;
         }
@@ -249,6 +253,9 @@ impl Configuration {
         }
         if command_line.focus_toggles_toolbars {
             self.focus_toggles_toolbars = command_line.focus_toggles_toolbars
+        }
+        if command_line.default_fill_shapes {
+            self.default_fill_shapes = command_line.default_fill_shapes;
         }
         if let Some(v) = command_line.initial_tool {
             self.initial_tool = v.into();
@@ -371,6 +378,10 @@ impl Configuration {
         self.focus_toggles_toolbars
     }
 
+    pub fn default_fill_shapes(&self) -> bool {
+        self.default_fill_shapes
+    }
+
     pub fn primary_highlighter(&self) -> Highlighters {
         self.primary_highlighter
     }
@@ -414,6 +425,7 @@ impl Default for Configuration {
             color_palette: ColorPalette::default(),
             default_hide_toolbars: false,
             focus_toggles_toolbars: false,
+            default_fill_shapes: false,
             font: FontConfiguration::default(),
             primary_highlighter: Highlighters::Block,
             disable_notifications: false,
@@ -470,6 +482,7 @@ struct ConfigurationFileGeneral {
     actions_on_right_click: Option<Vec<Action>>,
     default_hide_toolbars: Option<bool>,
     focus_toggles_toolbars: Option<bool>,
+    default_fill_shapes: Option<bool>,
     primary_highlighter: Option<Highlighters>,
     disable_notifications: Option<bool>,
     no_window_decoration: Option<bool>,

--- a/src/style.rs
+++ b/src/style.rs
@@ -40,7 +40,7 @@ impl Default for Style {
         Self {
             color: Color::default(),
             size: Size::default(),
-            fill: bool::default(),
+            fill: APP_CONFIG.read().default_fill_shapes(),
             annotation_size_factor: APP_CONFIG.read().annotation_size_factor(),
         }
     }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -461,7 +461,11 @@ impl Component for StyleToolbar {
                 set_focusable: false,
                 set_hexpand: false,
 
-                set_icon_name: "paint-bucket-regular",
+                set_icon_name: if APP_CONFIG.read().default_fill_shapes() {
+                    "paint-bucket-filled"
+                } else {
+                    "paint-bucket-regular"
+                },
                 set_tooltip: "Fill shape",
                 connect_clicked[sender] => move |button| {
                     sender.output_sender().emit(ToolbarEvent::ToggleFill);


### PR DESCRIPTION
This PR add the `default-fill-shapes` option, which makes Satty fill the shapes by default. I also updated the readme to be up to date with the current help output.