### PR TITLE
fix: lint

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -4,7 +4,7 @@ use relm4::gtk::gio::{prelude::ApplicationExt, Notification};
 use relm4::gtk::{IconLookupFlags, IconTheme, TextDirection};
 
 pub fn log_result(msg: &str, notify: bool) {
-    println!("{}", msg);
+    println!("{msg}");
     if notify {
         show_notification(msg);
     }

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -252,11 +252,10 @@ impl SketchBoard {
 
         if result.is_err() {
             println!(
-                "Warning: Could not format filename {} due to chrono format error, falling back to literal filename.",
-                output_filename
+                "Warning: Could not format filename {output_filename} due to chrono format error, falling back to literal filename."
             );
         } else {
-            output_filename = format!("{}", delayed_format);
+            output_filename = format!("{delayed_format}");
         }
 
         // TODO: we could support more data types

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -514,7 +514,7 @@ impl Component for StyleToolbar {
             StyleToolbarInput::AnnotationDialogFinished(value) => {
                 if let Some(value) = value {
                     self.annotation_size = value;
-                    self.annotation_size_formatted = format!("{0:.2}", value);
+                    self.annotation_size_formatted = format!("{value:.2}");
 
                     sender
                         .output_sender()
@@ -789,7 +789,7 @@ impl Component for AnnotationSizeDialog {
                 if let Err(e) = sender.output(AnnotationSizeDialogOutput::AnnotationSizeSubmitted(
                     self.annotation_size,
                 )) {
-                    eprintln!("Error submitting annotation size factor: {:?}", e);
+                    eprintln!("Error submitting annotation size factor: {e:?}");
                 }
                 root.hide();
             }


### PR DESCRIPTION
Closes #253

Inline format args allowed since rustc 1.66, should be OK. See https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args