### PR TITLE
feat: single-key and number-key tool shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ All configuration is done either at the config file in `XDG_CONFIG_DIR/.config/s
 - `Ctrl+Y`: Redo
 - `Ctrl+Z`: Undo
 
+#### Tool Selection Shortcuts (configurable)
+Default single-key shortcuts:
+- `P`: Pointer tool
+- `C`: Crop tool
+- `B`: Brush tool
+- `I`: Line tool
+- `Z`: Arrow tool
+- `R`: Rectangle tool
+- `E`: Ellipse tool
+- `T`: Text tool
+- `M`: Marker tool
+- `U`: Blur tool
+- `G`: Highlight tool
+
 ### Tool Modifiers and Keys
 
 - Arrow: Hold `Shift` to make arrow snap to 15° steps
@@ -103,6 +117,20 @@ right-click-copy = false
 no-window-decoration = true
 # experimental feature: adjust history size for brush input smooting (0: disabled, default: 0, try e.g. 5 or 10)
 brush-smooth-history-size = 10
+
+# Tool selection keyboard shortcuts
+[keybinds]
+pointer = "p"
+crop = "c"
+brush = "b"
+line = "i"
+arrow = "z"
+rectangle = "r"
+ellipse = "e"
+text = "t"
+marker = "m"
+blur = "u"
+highlight = "g"
 
 # Font to use for text annotations
 [font]

--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,20 @@ primary-highlighter = "block"
 # Disable notifications
 disable-notifications = false
 
+# Tool selection keyboard shortcuts (optional, defaults shown)
+#[keybinds]
+#pointer = "p"
+#crop = "c"
+#brush = "b"
+#line = "i"     
+#arrow = "z"    
+#rectangle = "r"
+#ellipse = "e"
+#text = "t"
+#marker = "m"
+#blur = "u"
+#highlight = "g" 
+
 # Font to use for text annotations
 [font]
 family = "Roboto"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs,
     io::{self, Write},
     path::Path,
@@ -54,6 +55,89 @@ pub struct Configuration {
     profile_startup: bool,
     no_window_decoration: bool,
     brush_smooth_history_size: usize,
+    keybinds: Keybinds,
+}
+
+pub struct Keybinds {
+    shortcuts: HashMap<String, Tools>,
+}
+
+impl Keybinds {
+    pub fn get_tool(&self, key: &str) -> Option<Tools> {
+        self.shortcuts.get(key).copied()
+    }
+
+    pub fn shortcuts(&self) -> &HashMap<String, Tools> {
+        &self.shortcuts
+    }
+
+    /// Merge [keybindings] with default
+    /// Only replaces defaults if they are set (doesn't )
+    fn merge(&mut self, file_keybinds: KeybindsFile) {
+        if let Some(pointer) = file_keybinds.pointer {
+            self.shortcuts.retain(|_, v| *v != Tools::Pointer);
+            self.shortcuts.insert(pointer, Tools::Pointer);
+        }
+        if let Some(crop) = file_keybinds.crop {
+            self.shortcuts.retain(|_, v| *v != Tools::Crop);
+            self.shortcuts.insert(crop, Tools::Crop);
+        }
+        if let Some(brush) = file_keybinds.brush {
+            self.shortcuts.retain(|_, v| *v != Tools::Brush);
+            self.shortcuts.insert(brush, Tools::Brush);
+        }
+        if let Some(line) = file_keybinds.line {
+            self.shortcuts.retain(|_, v| *v != Tools::Line);
+            self.shortcuts.insert(line, Tools::Line);
+        }
+        if let Some(arrow) = file_keybinds.arrow {
+            self.shortcuts.retain(|_, v| *v != Tools::Arrow);
+            self.shortcuts.insert(arrow, Tools::Arrow);
+        }
+        if let Some(rectangle) = file_keybinds.rectangle {
+            self.shortcuts.retain(|_, v| *v != Tools::Rectangle);
+            self.shortcuts.insert(rectangle, Tools::Rectangle);
+        }
+        if let Some(ellipse) = file_keybinds.ellipse {
+            self.shortcuts.retain(|_, v| *v != Tools::Ellipse);
+            self.shortcuts.insert(ellipse, Tools::Ellipse);
+        }
+        if let Some(text) = file_keybinds.text {
+            self.shortcuts.retain(|_, v| *v != Tools::Text);
+            self.shortcuts.insert(text, Tools::Text);
+        }
+        if let Some(marker) = file_keybinds.marker {
+            self.shortcuts.retain(|_, v| *v != Tools::Marker);
+            self.shortcuts.insert(marker, Tools::Marker);
+        }
+        if let Some(blur) = file_keybinds.blur {
+            self.shortcuts.retain(|_, v| *v != Tools::Blur);
+            self.shortcuts.insert(blur, Tools::Blur);
+        }
+        if let Some(highlight) = file_keybinds.highlight {
+            self.shortcuts.retain(|_, v| *v != Tools::Highlight);
+            self.shortcuts.insert(highlight, Tools::Highlight);
+        }
+    }
+}
+
+impl Default for Keybinds {
+    fn default() -> Self {
+        let mut shortcuts = HashMap::new();
+        shortcuts.insert("p".to_string(), Tools::Pointer);
+        shortcuts.insert("c".to_string(), Tools::Crop);
+        shortcuts.insert("b".to_string(), Tools::Brush);
+        shortcuts.insert("i".to_string(), Tools::Line);
+        shortcuts.insert("z".to_string(), Tools::Arrow);
+        shortcuts.insert("r".to_string(), Tools::Rectangle);
+        shortcuts.insert("e".to_string(), Tools::Ellipse);
+        shortcuts.insert("t".to_string(), Tools::Text);
+        shortcuts.insert("m".to_string(), Tools::Marker);
+        shortcuts.insert("u".to_string(), Tools::Blur);
+        shortcuts.insert("g".to_string(), Tools::Highlight);
+
+        Self { shortcuts }
+    }
 }
 
 #[derive(Default)]
@@ -236,6 +320,9 @@ impl Configuration {
             if let Some(v) = file.font {
                 self.font.merge(v);
             }
+            if let Some(v) = file.keybinds {
+                self.keybinds.merge(v);
+            }
         }
 
         // overwrite with all specified values from command line
@@ -405,6 +492,10 @@ impl Configuration {
     pub fn brush_smooth_history_size(&self) -> usize {
         self.brush_smooth_history_size
     }
+
+    pub fn keybinds(&self) -> &Keybinds {
+        &self.keybinds
+    }
 }
 
 impl Default for Configuration {
@@ -432,6 +523,7 @@ impl Default for Configuration {
             profile_startup: false,
             no_window_decoration: false,
             brush_smooth_history_size: 0, // default to 0, no history
+            keybinds: Keybinds::default(),
         }
     }
 }
@@ -457,6 +549,23 @@ struct ConfigurationFile {
     general: Option<ConfigurationFileGeneral>,
     color_palette: Option<ColorPaletteFile>,
     font: Option<FontFile>,
+    keybinds: Option<KeybindsFile>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct KeybindsFile {
+    pointer: Option<String>,
+    crop: Option<String>,
+    brush: Option<String>,
+    line: Option<String>,
+    arrow: Option<String>,
+    rectangle: Option<String>,
+    ellipse: Option<String>,
+    text: Option<String>,
+    marker: Option<String>,
+    blur: Option<String>,
+    highlight: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -6,7 +6,6 @@ use gdk_pixbuf::glib::Bytes;
 use gdk_pixbuf::Pixbuf;
 use keycode::{KeyMap, KeyMappingId};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::io::Write;
 use std::panic;
 use std::process::{Command, Stdio};
@@ -487,19 +486,6 @@ impl SketchBoard {
         event: TextEventMsg,
         sender: ComponentSender<Self>,
     ) -> ToolUpdateResult {
-        let tool_shortcuts = HashMap::from([
-            (("p", ""), Tools::Pointer),
-            (("c", "1"), Tools::Crop),
-            (("b", "2"), Tools::Brush),
-            (("l", "3"), Tools::Line),
-            (("a", "4"), Tools::Arrow),
-            (("r", "5"), Tools::Rectangle),
-            (("e", "6"), Tools::Ellipse),
-            (("t", "7"), Tools::Text),
-            (("m", "8"), Tools::Marker),
-            (("u", "9"), Tools::Blur),
-            (("h", "0"), Tools::Highlight),
-        ]);
         match event {
             TextEventMsg::Commit(txt) => {
                 // NOTE:
@@ -519,17 +505,14 @@ impl SketchBoard {
                     ToolUpdateResult::Unmodified
                 } else {
                     let key = txt.as_str();
-                    if let Some(tool) = tool_shortcuts
-                        .iter()
-                        .find(|item| item.0.0 == key || item.0.1 == key)
-                        .map(|(_, tool)| tool)
+                    if let Some(tool) = APP_CONFIG.read().keybinds().get_tool(key)
                     {
                         sender.input(SketchBoardInput::ToolbarEvent(ToolbarEvent::ToolSelected(
-                            *tool,
+                            tool,
                         )));
                         sender
                             .output_sender()
-                            .emit(SketchBoardOutput::ToolSwitchShortcut(*tool));
+                            .emit(SketchBoardOutput::ToolSwitchShortcut(tool));
 
                         ToolUpdateResult::Unmodified
                     } else {

--- a/src/tools/arrow.rs
+++ b/src/tools/arrow.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Arrow {
@@ -21,9 +21,22 @@ pub struct Arrow {
 pub struct ArrowTool {
     arrow: Option<Arrow>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for ArrowTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Arrow
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/blur.rs
+++ b/src/tools/blur.rs
@@ -12,7 +12,7 @@ use crate::{
     style::{Size, Style},
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Debug)]
 pub struct Blur {
@@ -133,9 +133,22 @@ impl Drawable for Blur {
 pub struct BlurTool {
     blur: Option<Blur>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for BlurTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Blur
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/brush.rs
+++ b/src/tools/brush.rs
@@ -6,12 +6,13 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Default)]
 pub struct BrushTool {
     drawable: Option<BrushDrawable>,
     style: Style,
+    input_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +45,18 @@ impl Drawable for BrushDrawable {
 }
 
 impl Tool for BrushTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Brush
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {

--- a/src/tools/crop.rs
+++ b/src/tools/crop.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use femtovg::{Color, Paint, Path};
 use relm4::gtk::gdk::Key;
 
-use super::{Drawable, Tool, ToolUpdateResult};
+use super::{Drawable, Tool, ToolUpdateResult, Tools};
 
 #[derive(Debug, Clone)]
 pub struct Crop {
@@ -21,6 +21,7 @@ pub struct Crop {
 pub struct CropTool {
     crop: Option<Crop>,
     action: Option<CropToolAction>,
+    input_enabled: bool,
 }
 
 impl Crop {
@@ -361,6 +362,18 @@ impl CropTool {
 }
 
 impl Tool for CropTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Crop
+    }
+
     fn handle_key_event(&mut self, event: KeyEventMsg) -> ToolUpdateResult {
         if event.key == Key::Escape && self.crop.is_some() {
             self.handle_deactivated()

--- a/src/tools/ellipse.rs
+++ b/src/tools/ellipse.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Ellipse {
@@ -47,9 +47,22 @@ impl Drawable for Ellipse {
 pub struct EllipseTool {
     ellipse: Option<Ellipse>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for EllipseTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Ellipse
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         match event.type_ {

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -15,7 +15,7 @@ use crate::{
     tools::DrawableClone,
 };
 
-use super::{Drawable, Tool, ToolUpdateResult};
+use super::{Drawable, Tool, ToolUpdateResult, Tools};
 
 const HIGHLIGHT_OPACITY: f64 = 0.4;
 
@@ -129,6 +129,7 @@ enum HighlightKind {
 pub struct HighlightTool {
     highlighter: Option<HighlightKind>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Drawable for HighlightKind {
@@ -145,6 +146,18 @@ impl Drawable for HighlightKind {
 }
 
 impl Tool for HighlightTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Highlight
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         let ctrl_pressed = event.modifier.intersects(ModifierType::CONTROL_MASK);

--- a/src/tools/line.rs
+++ b/src/tools/line.rs
@@ -8,12 +8,13 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Default)]
 pub struct LineTool {
     line: Option<Line>,
     style: Style,
+    input_enabled: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -49,6 +50,14 @@ impl Drawable for Line {
 }
 
 impl Tool for LineTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         match event.type_ {
             MouseEventType::BeginDrag => {
@@ -117,5 +126,9 @@ impl Tool for LineTool {
             Some(d) => Some(d),
             None => None,
         }
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Line
     }
 }

--- a/src/tools/marker.rs
+++ b/src/tools/marker.rs
@@ -8,11 +8,12 @@ use crate::sketch_board::{MouseButton, MouseEventType};
 use crate::style::Style;
 use crate::{math::Vec2D, sketch_board::MouseEventMsg};
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 pub struct MarkerTool {
     style: Style,
     next_number: Rc<RefCell<u16>>,
+    input_enabled: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -84,6 +85,18 @@ impl Drawable for Marker {
 }
 
 impl Tool for MarkerTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Marker
+    }
+
     fn get_drawable(&self) -> Option<&dyn Drawable> {
         None
     }
@@ -122,6 +135,7 @@ impl Default for MarkerTool {
         Self {
             style: Default::default(),
             next_number: Rc::new(RefCell::new(1)),
+            input_enabled: true
         }
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -91,6 +91,10 @@ pub trait Tool {
         false
     }
 
+    fn input_enabled(&self) -> bool;
+
+    fn set_input_enabled(&mut self, value: bool);
+
     fn handle_undo(&mut self) -> ToolUpdateResult {
         ToolUpdateResult::Unmodified
     }
@@ -100,6 +104,8 @@ pub trait Tool {
     }
 
     fn get_drawable(&self) -> Option<&dyn Drawable>;
+
+    fn get_tool_type(&self) -> Tools;
 }
 
 // the clone method below has been adapted from: https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object

--- a/src/tools/pointer.rs
+++ b/src/tools/pointer.rs
@@ -1,10 +1,24 @@
-use super::Tool;
+use super::{Tool, Tools};
 
 #[derive(Default)]
-pub struct PointerTool {}
+pub struct PointerTool {
+    input_enabled: bool,
+}
 
 impl Tool for PointerTool {
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Pointer
+    }
+
     fn get_drawable(&self) -> Option<&dyn super::Drawable> {
         None
+    }
+
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
     }
 }

--- a/src/tools/rectangle.rs
+++ b/src/tools/rectangle.rs
@@ -9,7 +9,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Rectangle {
@@ -54,9 +54,18 @@ impl Drawable for Rectangle {
 pub struct RectangleTool {
     rectangle: Option<Rectangle>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for RectangleTool {
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn handle_mouse_event(&mut self, event: MouseEventMsg) -> ToolUpdateResult {
         let shift_pressed = event.modifier.intersects(ModifierType::SHIFT_MASK);
         match event.type_ {
@@ -138,5 +147,9 @@ impl Tool for RectangleTool {
             Some(d) => Some(d),
             None => None,
         }
+    }
+
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Rectangle
     }
 }

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -13,7 +13,7 @@ use crate::{
     style::Style,
 };
 
-use super::{Drawable, DrawableClone, Tool, ToolUpdateResult};
+use super::{Drawable, DrawableClone, Tool, ToolUpdateResult, Tools};
 
 #[derive(Clone, Debug)]
 pub struct Text {
@@ -155,9 +155,22 @@ impl Drawable for Text {
 pub struct TextTool {
     text: Option<Text>,
     style: Style,
+    input_enabled: bool,
 }
 
 impl Tool for TextTool {
+    fn get_tool_type(&self) -> super::Tools {
+        Tools::Text
+    }
+
+    fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+
+    fn set_input_enabled(&mut self, value: bool) {
+        self.input_enabled = value;
+    }
+
     fn get_drawable(&self) -> Option<&dyn Drawable> {
         match &self.text {
             Some(d) => Some(d),
@@ -198,6 +211,7 @@ impl Tool for TextTool {
                     t.editing = false;
                     let result = t.clone_box();
                     self.text = None;
+                    self.input_enabled = false;
                     return ToolUpdateResult::Commit(result);
                 }
             } else if event.key == Key::Escape {
@@ -290,8 +304,11 @@ impl Tool for TextTool {
                     // create a new Text
                     self.text = Some(Text::new(event.pos, self.style));
 
+                    self.set_input_enabled(true);
+
                     return_value
                 } else {
+                    self.set_input_enabled(false);
                     ToolUpdateResult::Unmodified
                 }
             }

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -144,7 +144,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "cursor-regular",
-                set_tooltip: "Pointer (P)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Pointer,
             },
             #[name(crop_button)]
@@ -153,7 +153,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "crop-filled",
-                set_tooltip: "Crop (C)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Crop,
             },
             #[name(brush_button)]
@@ -162,7 +162,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "pen-regular",
-                set_tooltip: "Brush tool (B)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Brush,
             },
             #[name(line_button)]
@@ -171,7 +171,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "minus-large",
-                set_tooltip: "Line tool (L)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Line,
             },
             #[name(arrow_button)]
@@ -180,7 +180,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "arrow-up-right-filled",
-                set_tooltip: "Arrow tool (A)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Arrow,
             },
             #[name(rectangle_button)]
@@ -189,7 +189,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "checkbox-unchecked-regular",
-                set_tooltip: "Rectangle tool (R)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Rectangle,
             },
             #[name(ellipse_button)]
@@ -198,7 +198,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "circle-regular",
-                set_tooltip: "Ellipse tool (E)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Ellipse,
             },
             #[name(text_button)]
@@ -207,7 +207,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "text-case-title-regular",
-                set_tooltip: "Text tool (T)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Text,
             },
             #[name(marker_button)]
@@ -216,7 +216,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "number-circle-1-regular",
-                set_tooltip: "Numbered Marker (M)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Marker,
             },
             #[name(blur_button)]
@@ -225,7 +225,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "drop-regular",
-                set_tooltip: "Blur (U)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Blur,
             },
             #[name(highlight_button)]
@@ -234,7 +234,7 @@ impl SimpleComponent for ToolsToolbar {
                 set_hexpand: false,
 
                 set_icon_name: "highlight-regular",
-                set_tooltip: "Highlight (H)",
+                // tooltip set programatically
                 ActionablePlus::set_action::<ToolsAction>: Tools::Highlight,
             },
             gtk::Separator {},
@@ -304,6 +304,40 @@ impl SimpleComponent for ToolsToolbar {
             (Tools::Blur, widgets.blur_button.clone()),
             (Tools::Highlight, widgets.highlight_button.clone()),
         ]);
+
+        // reverse shortcuts
+        let config = APP_CONFIG.read();
+        let tool_to_key_map: HashMap<&Tools, &String> = config
+            .keybinds()
+            .shortcuts()
+            .iter()
+            .map(|(k, v)| (v, k))
+            .collect();
+
+        // Update tooltips based on configured keybinds
+        for (tool, button) in &model.tool_buttons {
+            let tool_name = match tool {
+                Tools::Pointer => "Pointer",
+                Tools::Crop => "Crop",
+                Tools::Brush => "Brush tool",
+                Tools::Line => "Line tool",
+                Tools::Arrow => "Arrow tool",
+                Tools::Rectangle => "Rectangle tool",
+                Tools::Ellipse => "Ellipse tool",
+                Tools::Text => "Text tool",
+                Tools::Marker => "Numbered Marker",
+                Tools::Blur => "Blur",
+                Tools::Highlight => "Highlight",
+            };
+
+            let tooltip = if let Some(key) = tool_to_key_map.get(tool) {
+                format!("{} ({})", tool_name, key)
+            } else {
+                tool_name.to_string()
+            };
+
+            button.set_tooltip(&tooltip);
+        }
 
         model.active_button = Some(widgets.pointer_button.clone());
 


### PR DESCRIPTION
Based on the work of @gabrielgcma and their PR:  #148

### Things done on top of their:
- merged main
- added shortcut keybinding configuration

### Things changed of their PR:
- let gtk handle ui update

I'm not familiar with gtk / relm4, but llm helped make [commit](https://github.com/gabm/Satty/commit/e634d88ee28905dbe163fb0043b17f6de55c95db) to solve the issue where changing tool with shortcut made the `initial_tool` still seem selected.
[Kooha-2025-09-25-05-37-23.webm](https://github.com/user-attachments/assets/93f770b7-3d9c-4d06-8d78-bd98d08652b4)


## Testing
Have tested using keybindings, and modifying `config.toml`