### PR TITLE
Replace Roboto Bold font in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ highlight = "g"
 # Font to use for text annotations
 [font]
 family = "Roboto"
-style = "Bold"
+style = "Regular"
 
 # Custom colours for the colour palette
 [color-palette]


### PR DESCRIPTION
Fixes: #247

no other traces of "Bold" found anywhere.