### PR TITLE
fix text tool cursor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Default single-key shortcuts:
 - Highlight: Hold `Ctrl` to switch between block and freehand mode (default configurable, see below), hold Shift for a square (if the default mode is block) or a straight line (if the default mode is freehand)
 - Line: Hold `Shift` to make line snap to 15° steps
 - Rectangle: Hold `Alt` to center the rectangle around origin, hold `Shift` for a square
-- Text: Press `Shift+Enter` to insert line break, combine `Ctrl` with `Left` or `Right` for word jump or `Ctrl` with `Backspace` or `Delete` for word delete. Press `Enter` or switch to another tool to accept input, press `Escape` to discard entered text.
+- Text: Press `Shift+Enter` to insert line break, combine `Ctrl` with `Left` or `Right` for word jump or `Ctrl` with `Backspace` or `Delete` for word delete. Press `Enter` or switch to another tool to accept input, press `Escape` to discard entered text. `Home` and `End` go to the start/end of current line or previous/next line if already on first/last character of line (automatic wrapping is not considered for this). `Ctrl` with `Home`/`End` jumps to start/end of text buffer.
 
 ### Configuration File
 

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -155,8 +155,8 @@ impl Drawable for Text {
         if self.editing {
             // function to draw a cursor
             let mut draw_cursor = |x, y: f32, height| {
-                // 20% extra height for cursor w.r.t. font height
-                let extra_height = height * 0.1;
+                // 10% extra height for cursor w.r.t. font height
+                let extra_height = height * 0.05;
 
                 let mut path = Path::new();
                 path.move_to(x, y - extra_height);
@@ -168,11 +168,13 @@ impl Drawable for Text {
             let mut previous_lines_bytes_offset = 0;
             let mut cursor_drawn = false;
 
-            for m in metrics.iter() {
+            for (line_idx, m) in metrics.iter().enumerate() {
                 for g in &m.glyphs {
                     if previous_lines_bytes_offset + g.byte_index == cursor_byte_pos {
                         // cursor is before this glyph, draw here!
-                        draw_cursor(g.x - g.bearing_x, m.y, m.height());
+                        let cursor_y =
+                            self.pos.y + line_idx as f32 * line_height + cursor_top_offset;
+                        draw_cursor(g.x - g.bearing_x, cursor_y, cursor_height);
                         cursor_drawn = true;
                         break;
                     }
@@ -192,9 +194,9 @@ impl Drawable for Text {
                     if let Some(g) = m.glyphs.last() {
                         if g.c == '\n' {
                             // if last char is a manual wrap -> draw cursor on next line
-                            let baseline = self.pos.y + metrics.len() as f32 * line_height;
-                            let next_cursor_top = baseline + cursor_top_offset;
-                            draw_cursor(self.pos.x, next_cursor_top, cursor_height);
+                            let cursor_y =
+                                self.pos.y + metrics.len() as f32 * line_height + cursor_top_offset;
+                            draw_cursor(self.pos.x, cursor_y, cursor_height);
                         } else {
                             // on the same line as last glyph
                             draw_cursor(g.x + g.bearing_x + g.width, m.y, m.height());


### PR DESCRIPTION
Closes: #223

After looking at this with a debugger, I do not agree that femtovg is not reporting line breaks in the byte index. The problem is rather that we cannot distinguish first char (index 0 + last line last index) in a new line from the last char in the last line (last line last index).

Debugger:
<img width="2677" height="1119" alt="satty-20251005-072901" src="https://github.com/user-attachments/assets/61f2138e-0c19-4a72-9dac-85419c03600b" />

Behaviour after fix:
https://github.com/user-attachments/assets/e9db27f1-a189-445c-9be0-8770820c4767

Cursor height, positioning relative to char can still be tweaked on the back of a followup issue.